### PR TITLE
Refactor webhook response handling to use jsonResponse helper

### DIFF
--- a/internal/admin/handlers_app.go
+++ b/internal/admin/handlers_app.go
@@ -315,9 +315,7 @@ func (s *Server) handleDeployWebhook(w http.ResponseWriter, r *http.Request) {
 	// Check if this is a push event (GitHub sends X-GitHub-Event header)
 	event := r.Header.Get("X-GitHub-Event")
 	if event != "" && event != "push" && event != "ping" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"status": "ignored", "event": event})
+		jsonResponse(w, map[string]string{"status": "ignored", "event": event})
 		return
 	}
 	// Respond to ping
@@ -349,7 +347,5 @@ func (s *Server) handleDeployWebhook(w http.ResponseWriter, r *http.Request) {
 		}
 	})
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "deploying", "branch": branch})
+	jsonResponse(w, map[string]string{"status": "deploying", "branch": branch})
 }


### PR DESCRIPTION
## Summary
Refactored the `handleDeployWebhook` function to use a `jsonResponse` helper function instead of manually setting headers and encoding JSON responses. This reduces code duplication and improves maintainability.

## Key Changes
- Replaced manual JSON response handling (setting `Content-Type` header, writing status code, and encoding JSON) with calls to `jsonResponse()` helper function
- Applied refactoring to two response points in the webhook handler:
  - Non-push event response (ignored events)
  - Successful deployment response

## Implementation Details
The changes consolidate repetitive response handling logic by delegating to the `jsonResponse` helper, which presumably handles:
- Setting the `Content-Type: application/json` header
- Writing the HTTP 200 status code
- Encoding and writing the JSON response body

This improves code consistency and reduces the likelihood of response handling bugs in future modifications.

https://claude.ai/code/session_01FW8CizQpnVNYHqfa8fURzp