### PR TITLE
security: bind admin PIN into the WebSocket ticket (VULN-029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Token in URL removed (Low):** the legacy `?token=` query-param auth fallback
   for SSE/WebSocket was removed (it leaked live tokens/keys to history, Referer,
   and proxy logs); the single-use `?ticket=` flow is now required.
+- **PIN out of WebSocket URL (Low, VULN-029):** the admin PIN is now bound into
+  the single-use ticket at mint time (verified via the `X-Pin-Code` header on
+  the HTTP mint request) and carried through redemption into the request
+  context, so the terminal WebSocket no longer puts the PIN in its URL. `?pin=`
+  is accepted only in the no-auth bypass mode where a ticket can't be minted.
 - **Session TTL honored (Low):** `global.users.session_ttl` was silently ignored
   (lifetime hardcoded to 24h); it is now threaded into the auth manager.
 - **PIN brute-force protection (Low):** failed admin-PIN attempts now feed the

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
@@ -379,6 +380,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 
 		var authenticated bool
 		var user *auth.User
+		var ticketPinVerified bool
 
 		// Try multi-user auth first if enabled
 		if multiUserEnabled && s.authMgr != nil {
@@ -407,7 +409,8 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			// Check ticket query param for SSE/WebSocket (short-lived, single-use).
 			if !authenticated {
 				if ticket := r.URL.Query().Get("ticket"); ticket != "" {
-					if realToken := s.redeemTicket(ticket); realToken != "" {
+					realToken, pinOK := s.redeemTicket(ticket)
+					if realToken != "" {
 						// Try as session token first
 						if session, err := s.authMgr.ValidateSession(realToken); err == nil {
 							if u, exists := s.authMgr.GetUserByID(session.UserID); exists {
@@ -424,6 +427,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 						}
 					}
 					if authenticated {
+						ticketPinVerified = pinOK
 						q := r.URL.Query()
 						q.Del("ticket")
 						r.URL.RawQuery = q.Encode()
@@ -442,8 +446,9 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			// Check ticket query param first (preferred), then legacy token param
 			if authHeader == "" {
 				if ticket := r.URL.Query().Get("ticket"); ticket != "" {
-					if realToken := s.redeemTicket(ticket); realToken != "" {
+					if realToken, pinOK := s.redeemTicket(ticket); realToken != "" {
 						authHeader = "Bearer " + realToken
+						ticketPinVerified = pinOK
 					}
 				}
 			}
@@ -467,6 +472,9 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 
 		// Store user in context for handlers to access
 		ctx := auth.WithUser(r.Context(), user)
+		if ticketPinVerified {
+			ctx = context.WithValue(ctx, ctxPinVerified, true)
+		}
 		r = r.WithContext(ctx)
 
 		// 2FA check for legacy auth: if TOTP is enabled, require valid code.

--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -2813,15 +2813,47 @@ func TestAuthTicketIssueAndRedeem(t *testing.T) {
 	}
 
 	// Redeem the ticket
-	token := s.redeemTicket(ticket)
+	token, _ := s.redeemTicket(ticket)
 	if token != "test-token-123" {
 		t.Errorf("redeemed token = %q, want %q", token, "test-token-123")
 	}
 
 	// Second redeem should fail (single-use)
-	token2 := s.redeemTicket(ticket)
+	token2, _ := s.redeemTicket(ticket)
 	if token2 != "" {
 		t.Errorf("second redeem should return empty, got %q", token2)
+	}
+}
+
+// TestRequirePinTicketBound is the regression for VULN-029: a ticket minted
+// with a valid PIN satisfies requirePin without the PIN ever being in the URL,
+// and the raw ?pin= query is rejected once auth is configured.
+func TestRequirePinTicketBound(t *testing.T) {
+	s := testServer()
+	s.config.Global.Admin.PinCode = "1234"
+	s.config.Global.Admin.APIKey = "k" // authenticated mode → ?pin= disallowed
+
+	// Ticket-bound PIN (context flag) passes without any header/query PIN.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/terminal", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxPinVerified, true))
+	if !s.requirePin(rec, req) {
+		t.Errorf("ticket-bound PIN should satisfy requirePin (status=%d)", rec.Code)
+	}
+
+	// Raw ?pin= in the URL is rejected in authenticated mode.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/api/v1/terminal?pin=1234", nil)
+	if s.requirePin(rec2, req2) {
+		t.Error("?pin= query must be rejected when auth is configured")
+	}
+
+	// Header PIN still works for normal HTTP requests.
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest("GET", "/api/v1/backup", nil)
+	req3.Header.Set("X-Pin-Code", "1234")
+	if !s.requirePin(rec3, req3) {
+		t.Errorf("header PIN should satisfy requirePin (status=%d)", rec3.Code)
 	}
 }
 
@@ -2833,7 +2865,7 @@ func TestAuthTicketExpiry(t *testing.T) {
 		created: time.Now().Add(-60 * time.Second), // 60s ago, well past 30s TTL
 	}
 
-	token := s.redeemTicket("expired-ticket")
+	token, _ := s.redeemTicket("expired-ticket")
 	if token != "" {
 		t.Errorf("expired ticket should return empty, got %q", token)
 	}

--- a/internal/admin/handlers_auth.go
+++ b/internal/admin/handlers_auth.go
@@ -18,10 +18,18 @@ import (
 )
 
 type authTicket struct {
-	token     string    // the real session token or API key
-	created   time.Time // when the ticket was issued
-	expiresAt time.Time // when the ticket expires
+	token       string    // the real session token or API key
+	created     time.Time // when the ticket was issued
+	expiresAt   time.Time // when the ticket expires
+	pinVerified bool      // a valid admin PIN was presented when the ticket was minted
 }
+
+// adminCtxKey is the private context-key type for admin-middleware values.
+type adminCtxKey int
+
+// ctxPinVerified marks a request whose single-use ticket was minted with a
+// valid admin PIN — lets requirePin pass without the PIN traveling in the URL.
+const ctxPinVerified adminCtxKey = iota
 
 // handleAuthTicket issues a short-lived, single-use ticket that can be passed
 // as a query parameter for SSE/WebSocket connections. This avoids putting the
@@ -67,29 +75,51 @@ func (s *Server) handleAuthTicket(w http.ResponseWriter, r *http.Request) {
 			delete(s.tickets, k)
 		}
 	}
-	s.tickets[ticket] = &authTicket{token: realToken, created: now, expiresAt: now.Add(ticketTTL)}
+	// Bind PIN verification into the ticket: if the (header-authenticated)
+	// mint request carried a valid PIN, the redeemed ticket satisfies requirePin
+	// so the PIN never has to travel in the WebSocket URL.
+	s.tickets[ticket] = &authTicket{
+		token:       realToken,
+		created:     now,
+		expiresAt:   now.Add(ticketTTL),
+		pinVerified: s.pinSatisfied(r),
+	}
 	s.ticketMu.Unlock()
 
 	jsonResponse(w, map[string]any{"ticket": ticket, "expires_at": now.Add(ticketTTL)})
 }
 
-// redeemTicket exchanges a single-use ticket for the real auth token.
-// Returns empty string if the ticket is invalid or expired.
-// Uses atomic delete — single-use: once redeemed, the ticket is deleted.
-func (s *Server) redeemTicket(ticket string) string {
+// pinSatisfied reports whether the request carries a valid admin PIN via the
+// X-Pin-Code header (or no PIN is configured). Used to bind PIN verification
+// into a ticket at mint time.
+func (s *Server) pinSatisfied(r *http.Request) bool {
+	s.configMu.RLock()
+	pin := s.config.Global.Admin.PinCode
+	s.configMu.RUnlock()
+	if pin == "" {
+		return true
+	}
+	provided := r.Header.Get("X-Pin-Code")
+	return provided != "" && subtle.ConstantTimeCompare([]byte(provided), []byte(pin)) == 1
+}
+
+// redeemTicket exchanges a single-use ticket for the real auth token. Returns
+// the token ("" if invalid/expired) and whether the ticket was minted with a
+// valid admin PIN. Uses atomic delete — single-use: once redeemed, deleted.
+func (s *Server) redeemTicket(ticket string) (string, bool) {
 	s.ticketMu.Lock()
 	defer s.ticketMu.Unlock()
 	t, ok := s.tickets[ticket]
 	if !ok {
-		return ""
+		return "", false
 	}
 	if time.Now().After(t.expiresAt) {
 		delete(s.tickets, ticket)
-		return ""
+		return "", false
 	}
-	// Single-use: delete now so it cannot be redeemed again, then return the token.
+	// Single-use: delete now so it cannot be redeemed again, then return.
 	delete(s.tickets, ticket)
-	return t.token
+	return t.token, t.pinVerified
 }
 
 func (s *Server) requireDomainAccess(w http.ResponseWriter, r *http.Request, domain, action string) bool {
@@ -527,10 +557,18 @@ func (s *Server) handleUserChangePasswordAuth(w http.ResponseWriter, r *http.Req
 func (s *Server) requirePin(w http.ResponseWriter, r *http.Request) bool {
 	s.configMu.RLock()
 	pin := s.config.Global.Admin.PinCode
+	apiKey := s.config.Global.Admin.APIKey
+	multiUser := s.config.Global.Users.Enabled
 	s.configMu.RUnlock()
 
 	if pin == "" {
 		return true // no pin configured, allow
+	}
+
+	// A single-use ticket minted with a valid PIN satisfies the PIN without it
+	// ever appearing in the WebSocket URL (VULN-029).
+	if v, ok := r.Context().Value(ctxPinVerified).(bool); ok && v {
+		return true
 	}
 
 	// Brute-force protection: a short numeric PIN must not be guessable. Block
@@ -544,8 +582,11 @@ func (s *Server) requirePin(w http.ResponseWriter, r *http.Request) bool {
 	}
 
 	provided := r.Header.Get("X-Pin-Code")
-	// WebSocket connections can't set headers — also check query param
-	if provided == "" {
+	// The PIN in a `?pin=` query param leaks to history/Referer/logs, so it is
+	// accepted ONLY in the no-auth bypass mode (no api_key, no multi-user) where
+	// a WebSocket cannot obtain a PIN-bound ticket. Every authenticated
+	// deployment must use the X-Pin-Code header or a PIN-bound ticket.
+	if provided == "" && apiKey == "" && !multiUser {
 		provided = r.URL.Query().Get("pin")
 	}
 	if provided == "" {

--- a/web/dashboard/src/lib/api.ts
+++ b/web/dashboard/src/lib/api.ts
@@ -1595,9 +1595,19 @@ export async function terminalWSURL(pin?: string): Promise<string> {
   const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const host = import.meta.env.DEV ? '127.0.0.1:9443' : window.location.host;
   const params = new URLSearchParams();
+  // Set the PIN globally first so the ticket-mint request (a normal HTTP call)
+  // carries it via the X-Pin-Code header — the server then binds PIN
+  // verification into the ticket, so the PIN never appears in this URL.
+  if (pin) setPinCode(pin);
   const ticket = await obtainTicket();
-  if (ticket) params.set('ticket', ticket);
-  if (pin) params.set('pin', pin);
+  if (ticket) {
+    params.set('ticket', ticket);
+    // PIN is bound into the ticket — do NOT put it in the URL.
+  } else if (pin) {
+    // No-auth mode: without a token there is no ticket to bind the PIN to, so
+    // fall back to the query param (the server accepts ?pin= only in this mode).
+    params.set('pin', pin);
+  }
   const qs = params.toString();
   return `${proto}//${host}/api/v1/terminal${qs ? '?' + qs : ''}`;
 }


### PR DESCRIPTION
## Summary

Closes **VULN-029** (Low, CWE-598): the web-terminal WebSocket passed the admin PIN as a `?pin=` query param, which leaks to browser history, `Referer`, and proxy logs.

The PIN is now **bound into the single-use auth ticket** at mint time:
- The ticket-mint request is a normal HTTP call, so it carries the PIN via the `X-Pin-Code` header; `handleAuthTicket` records a `pinVerified` flag on the ticket.
- `redeemTicket` returns that flag; `authMiddleware` propagates it into the request context.
- `requirePin` accepts a PIN-verified ticket — so the terminal WS no longer needs the PIN in its URL.
- `?pin=` is now accepted **only** in the no-auth bypass mode (no `api_key`, no multi-user), where a WebSocket can't obtain a PIN-bound ticket (the bypass authenticates before ticket redemption). Every authenticated deployment must use the header or a PIN-bound ticket.

The dashboard sets the PIN before requesting the ticket and no longer appends `?pin=` to the WebSocket URL (falling back to `?pin=` only when no ticket can be minted).

## Tests

- New `TestRequirePinTicketBound`: a PIN-verified ticket satisfies `requirePin`; raw `?pin=` is rejected in authenticated mode; the header path still works.
- `go build` / `go vet` / `go test ./internal/admin/` ✓ · `tsc -b` ✓

This was the last deferred item that could be fixed without a product decision; VULN-021/026/034 and INFO-3/4/6/7 remain documented decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)