### PR TITLE
security: pin CI tools + add Dependabot (INFO-7)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+# Keeps pinned dependencies fresh so version/SHA pinning is safe rather than a
+# source of frozen-vulnerable deps. Covers CI actions, Go modules, the
+# dashboard's npm deps, and the Docker base images.
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      go-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: "/web/dashboard"
+    schedule:
+      interval: weekly
+    groups:
+      dashboard-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,13 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # Pin tool versions (not @latest) for reproducible CI; Dependabot
+      # (.github/dependabot.yml) proposes bumps.
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
 
       - name: Lint (go vet + staticcheck)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bombs; enabling per-domain `proxy.insecure_skip_verify` now logs a warning;
   and `.dockerignore` excludes `.env*`/`*.key`/`*.pem`/`*.crt` from builder
   layers.
+- **Supply-chain hardening (Informational, INFO-7):** CI tool installs are
+  pinned (`govulncheck@v1.5.0`, `staticcheck@v0.7.0`) instead of `@latest`, and
+  a `.github/dependabot.yml` was added to keep GitHub Actions, Go modules,
+  dashboard npm deps, and Docker base images updated — the maintenance basis for
+  safely pinning actions/images (INFO-6, VULN-034).
 
 ## [0.8.6] - 2026-06-25
 


### PR DESCRIPTION
## Summary

Supply-chain hardening (INFO-7, and the maintenance basis for INFO-6 / VULN-034):

- **Pin CI tools** in `ci.yml`: `govulncheck@v1.5.0` and `staticcheck@v0.7.0` instead of `@latest`, for reproducible runs. Both verified to install/resolve.
- **Add `.github/dependabot.yml`** covering `github-actions`, `gomod`, `npm` (dashboard), and `docker`, on a weekly schedule with grouped PRs.

This makes future version/SHA pinning of actions and base images safe (Dependabot keeps them current instead of letting them freeze on a vulnerable pin), which is exactly the maintenance prerequisite that had VULN-034 and INFO-6 deferred.

No behavior change to the server or product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)