### PR TITLE
security: enforce role permissions on domain writes (VULN-021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Container hardening (Low):** compose services gained
   `no-new-privileges`, `pids_limit`, and (for the uwas service) `cap_drop: ALL`
   + `cap_add: NET_BIND_SERVICE`.
+- **RBAC enforcement (Low, VULN-021):** the declared `rolePermissions` model was
+  dead code — a read-only `user` could create/update/delete any assigned domain.
+  Domain create/update/delete handlers now enforce `HasPermission`
+  (`domain:create`/`update`/`delete`), so `user` is read-only and
+  `reseller`/`admin` retain write access, as the model already declared.
 - **Defense-in-depth hardening (Informational):** `validateShellCommand` now
   also rejects a lone `&` (background exec); the cPanel tar importer enforces
   aggregate size (50GB) and entry-count (500k) caps against decompression

--- a/internal/admin/admin_coverage2_test.go
+++ b/internal/admin/admin_coverage2_test.go
@@ -120,7 +120,22 @@ func (m *mockAuthManager) Logout(token string) {
 }
 
 func (m *mockAuthManager) HasPermission(role auth.Role, perm auth.Permission) bool {
-	return role == auth.RoleAdmin
+	// Mirror auth.rolePermissions so RBAC enforcement is exercised faithfully:
+	// admin = all; reseller = domain CRUD + reads + cert; user = read-only.
+	switch role {
+	case auth.RoleAdmin:
+		return true
+	case auth.RoleReseller:
+		switch perm {
+		case auth.PermDomainRead, auth.PermDomainCreate, auth.PermDomainUpdate,
+			auth.PermDomainDelete, auth.PermUserRead, auth.PermSystemRead, auth.PermCertManage:
+			return true
+		}
+		return false
+	case auth.RoleUser:
+		return perm == auth.PermDomainRead || perm == auth.PermSystemRead
+	}
+	return false
 }
 
 func (m *mockAuthManager) CanManageDomain(user *auth.User, domain string) bool {
@@ -231,6 +246,48 @@ func withResellerContext(r *http.Request) *http.Request {
 		Enabled: true, Domains: []string{"reseller.com"},
 	}
 	return r.WithContext(auth.WithUser(r.Context(), user))
+}
+
+func withUserContext(r *http.Request) *http.Request {
+	user := &auth.User{
+		ID: "user-id", Username: "user", Role: auth.RoleUser,
+		Enabled: true, Domains: []string{"user.com"},
+	}
+	return r.WithContext(auth.WithUser(r.Context(), user))
+}
+
+// TestRequirePermissionRBAC is the regression for VULN-021: the read-only
+// `user` role is denied domain writes while reseller/admin are allowed,
+// honoring the declared auth.rolePermissions model.
+func TestRequirePermissionRBAC(t *testing.T) {
+	s := testServer()
+	s.authMgr = newMockAuthManager()
+
+	writes := []auth.Permission{auth.PermDomainCreate, auth.PermDomainUpdate, auth.PermDomainDelete}
+
+	for _, perm := range writes {
+		// user (read-only) is denied every write permission
+		rec := httptest.NewRecorder()
+		if s.requirePermission(rec, withUserContext(httptest.NewRequest("POST", "/", nil)), perm) {
+			t.Errorf("user role should be denied %s", perm)
+		}
+		// reseller is allowed domain writes
+		rec2 := httptest.NewRecorder()
+		if !s.requirePermission(rec2, withResellerContext(httptest.NewRequest("POST", "/", nil)), perm) {
+			t.Errorf("reseller role should be allowed %s (status=%d)", perm, rec2.Code)
+		}
+		// admin is allowed
+		rec3 := httptest.NewRecorder()
+		if !s.requirePermission(rec3, withAdminContext(httptest.NewRequest("POST", "/", nil)), perm) {
+			t.Errorf("admin role should be allowed %s", perm)
+		}
+	}
+
+	// user CAN still read.
+	rec := httptest.NewRecorder()
+	if !s.requirePermission(rec, withUserContext(httptest.NewRequest("GET", "/", nil)), auth.PermDomainRead) {
+		t.Error("user role should be allowed domain:read")
+	}
 }
 
 // TestStateChangingRoutesRequireAdmin locks in the RBAC fix: these

--- a/internal/admin/handlers_auth.go
+++ b/internal/admin/handlers_auth.go
@@ -154,6 +154,27 @@ func (s *Server) isAdmin(r *http.Request) bool {
 	return ok && user.Role == auth.RoleAdmin
 }
 
+// requirePermission enforces the declared role-permission model
+// (auth.rolePermissions) for the authenticated user. Admins and single-key mode
+// always pass. This wires up the previously-unenforced model so a read-only
+// `user` role can no longer perform write actions (VULN-021).
+func (s *Server) requirePermission(w http.ResponseWriter, r *http.Request, perm auth.Permission) bool {
+	if s.authMgr == nil {
+		return true // single-key mode: the caller is the implicit admin
+	}
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		jsonError(w, "unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	if user.Role == auth.RoleAdmin || s.authMgr.HasPermission(user.Role, perm) {
+		return true
+	}
+	s.recordAuditR(r, "rbac.denied", string(perm), false)
+	jsonError(w, "forbidden: your role lacks the "+string(perm)+" permission", http.StatusForbidden)
+	return false
+}
+
 type adminUserResponse struct {
 	ID        string    `json:"id"`
 	Username  string    `json:"username"`

--- a/internal/admin/handlers_domain.go
+++ b/internal/admin/handlers_domain.go
@@ -117,6 +117,10 @@ func (s *Server) removeDomainFile(host string) {
 }
 
 func (s *Server) handleAddDomain(w http.ResponseWriter, r *http.Request) {
+	// Role-level check: a read-only `user` role cannot create domains.
+	if !s.requirePermission(w, r, auth.PermDomainCreate) {
+		return
+	}
 	// Check domain permissions for non-admin users
 	if s.authMgr != nil {
 		user, ok := auth.UserFromContext(r.Context())
@@ -431,6 +435,10 @@ func (s *Server) handleAddDomain(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeleteDomain(w http.ResponseWriter, r *http.Request) {
+	// Role-level check: a read-only `user` role cannot delete domains.
+	if !s.requirePermission(w, r, auth.PermDomainDelete) {
+		return
+	}
 	if !s.requirePin(w, r) {
 		return
 	}
@@ -567,6 +575,11 @@ func (s *Server) handleUpdateDomain(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	host := canonicalDomainHostname(r.PathValue("host"))
 	var currentUser *auth.User
+
+	// Role-level check: a read-only `user` role cannot modify domains.
+	if !s.requirePermission(w, r, auth.PermDomainUpdate) {
+		return
+	}
 
 	// Check domain permissions for non-admin users
 	if s.authMgr != nil {


### PR DESCRIPTION
## Summary

Closes **VULN-021** (Low, CWE-863): the `auth.rolePermissions` model was declared but never enforced. Enforcement was binary (`requireAdmin` vs `CanManageDomain` membership), so a role documented as read-only (`user`) could **create / update / delete** any domain it was assigned.

`rolePermissions` already declares the intended model:
- `admin` → all
- `reseller` → domain read/create/update/delete + user-read + cert
- `user` → **read-only** (`domain:read`, `system:read`)

This PR wires that model up for the concrete issue cited (domain writes):
- New `requirePermission(w, r, perm)` — admins and single-key mode always pass; otherwise checks `HasPermission`.
- `handleAddDomain` / `handleUpdateDomain` / `handleDeleteDomain` now gate on `PermDomainCreate` / `PermDomainUpdate` / `PermDomainDelete`.

Net effect: a `user` becomes read-only (as declared); `reseller`/`admin` are unaffected. Resource-level `CanManageDomain` checks remain on top of the new role-level checks.

## Why this is a faithful fix (not an arbitrary behavior change)

The read-only intent for `user` is already encoded in `rolePermissions`; this only makes enforcement match the declaration. The dead-code model is now live.

## Tests

- New `TestRequirePermissionRBAC`: `user` denied all domain writes but allowed reads; `reseller`/`admin` allowed writes.
- The test mock's `HasPermission` now mirrors the real `rolePermissions` (previously admin-only stub).
- `go build`/`vet`/`go test ./internal/admin/` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)