### PR TITLE
security: scope login lockout to (username, IP) (VULN-026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Container hardening (Low):** compose services gained
   `no-new-privileges`, `pids_limit`, and (for the uwas service) `cap_drop: ALL`
   + `cap_add: NET_BIND_SERVICE`.
+- **Per-(user,IP) login lockout (Low, VULN-026):** brute-force lockout was keyed
+  on username alone, so a flood from any source could lock a known operator out
+  everywhere (targeted-lockout DoS). Lockout is now scoped to (username, IP) via
+  the new `AuthenticateFrom`; the 12-char password policy covers distributed
+  many-IP brute force.
 - **RBAC enforcement (Low, VULN-021):** the declared `rolePermissions` model was
   dead code — a read-only `user` could create/update/delete any assigned domain.
   Domain create/update/delete handlers now enforce `HasPermission`

--- a/internal/admin/admin_coverage2_test.go
+++ b/internal/admin/admin_coverage2_test.go
@@ -98,6 +98,10 @@ func (m *mockAuthManager) Authenticate(username, password string) (*auth.Session
 	return sess, nil
 }
 
+func (m *mockAuthManager) AuthenticateFrom(username, password, _ string) (*auth.Session, error) {
+	return m.Authenticate(username, password)
+}
+
 func (m *mockAuthManager) AuthenticateAPIKey(key string) (*auth.User, error) {
 	for _, u := range m.users {
 		if u.APIKey == key {

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -147,6 +147,7 @@ type Server struct {
 // AuthManager interface for authentication (implemented by auth.Manager)
 type AuthManager interface {
 	Authenticate(username, password string) (*auth.Session, error)
+	AuthenticateFrom(username, password, clientIP string) (*auth.Session, error)
 	AuthenticateAPIKey(key string) (*auth.User, error)
 	ValidateSession(token string) (*auth.Session, error)
 	Logout(token string)

--- a/internal/admin/handlers_auth.go
+++ b/internal/admin/handlers_auth.go
@@ -657,7 +657,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, err := s.authMgr.Authenticate(req.Username, req.Password)
+	session, err := s.authMgr.AuthenticateFrom(req.Username, req.Password, requestIP(r))
 	if err != nil {
 		ip := requestIP(r)
 		s.recordAuthFailure(ip, req.Username)

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -415,17 +415,38 @@ var decoyHash = sync.OnceValue(func() []byte {
 	return h
 })
 
-// Authenticate validates credentials and returns a session.
+// lockoutKey scopes brute-force lockout to (username, IP) so a flood from one
+// IP can't lock a legitimate operator out from another IP (targeted-lockout
+// DoS), while still capping per-source guessing. Distributed (many-IP) brute
+// force is covered by the minimum-password-length policy. An empty IP falls
+// back to a username-only key (callers that don't supply a client IP).
+func lockoutKey(username, clientIP string) string {
+	if clientIP == "" {
+		return username
+	}
+	return username + "|" + clientIP
+}
+
+// Authenticate validates credentials and returns a session. Prefer
+// AuthenticateFrom so brute-force lockout is scoped per (username, IP).
 func (m *Manager) Authenticate(username, password string) (*Session, error) {
-	// Serialize attempts for this username so the lockout check below and the
-	// failure increment after the bcrypt compare are atomic together — without
-	// this, a concurrent burst all passes isLockedOut before any records a
-	// failure, admitting more than maxLoginAttempts tries.
-	gate := m.authGateFor(username)
+	return m.AuthenticateFrom(username, password, "")
+}
+
+// AuthenticateFrom validates credentials, scoping brute-force lockout to the
+// supplied client IP (see lockoutKey).
+func (m *Manager) AuthenticateFrom(username, password, clientIP string) (*Session, error) {
+	lockKey := lockoutKey(username, clientIP)
+
+	// Serialize attempts for this (username, IP) so the lockout check below and
+	// the failure increment after the bcrypt compare are atomic together —
+	// without this, a concurrent burst all passes isLockedOut before any records
+	// a failure, admitting more than maxLoginAttempts tries.
+	gate := m.authGateFor(lockKey)
 	gate.Lock()
 	defer gate.Unlock()
 
-	if m.isLockedOut(username) {
+	if m.isLockedOut(lockKey) {
 		return nil, errors.New("too many failed attempts; try again later")
 	}
 
@@ -436,7 +457,7 @@ func (m *Manager) Authenticate(username, password string) (*Session, error) {
 		// Spend the same bcrypt time as the real path to avoid leaking, via
 		// response timing, whether the username exists.
 		_ = bcrypt.CompareHashAndPassword(decoyHash(), []byte(password))
-		m.recordFailedAttempt(username)
+		m.recordFailedAttempt(lockKey)
 		return nil, errors.New("invalid credentials")
 	}
 	// Snapshot fields under the lock to avoid racing with UpdateUser.
@@ -449,16 +470,16 @@ func (m *Manager) Authenticate(username, password string) (*Session, error) {
 	m.mu.RUnlock()
 
 	if !enabled {
-		m.recordFailedAttempt(username)
+		m.recordFailedAttempt(lockKey)
 		return nil, errors.New("user disabled")
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)); err != nil {
-		m.recordFailedAttempt(username)
+		m.recordFailedAttempt(lockKey)
 		return nil, errors.New("invalid credentials")
 	}
 
-	m.clearFailedAttempts(username)
+	m.clearFailedAttempts(lockKey)
 
 	// Update last login lock-free. The atomic value is preferred by
 	// latestLastLogin and synced back into User.LastLogin by cloneUser and

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -16,6 +16,32 @@ func newTestManager(t *testing.T) *Manager {
 	return NewManager(t.TempDir(), "test-global-api-key")
 }
 
+// TestLockoutPerUsernameIP is the regression for VULN-026: brute-force lockout
+// is scoped to (username, IP), so a flood from one IP can't lock a legitimate
+// operator out from another IP (targeted-lockout DoS).
+func TestLockoutPerUsernameIP(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.CreateUser("victim", "", "S3cure-Passw0rd!", RoleUser, nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	const ipA, ipB = "10.0.0.1", "10.0.0.2"
+
+	// Exhaust the lockout from ipA with wrong passwords.
+	for i := 0; i < maxLoginAttempts; i++ {
+		if _, err := m.AuthenticateFrom("victim", "wrong", ipA); err == nil {
+			t.Fatalf("attempt %d should fail", i)
+		}
+	}
+	// ipA is now locked out even with the correct password.
+	if _, err := m.AuthenticateFrom("victim", "S3cure-Passw0rd!", ipA); err == nil {
+		t.Error("ipA should be locked out after exhausting attempts")
+	}
+	// ipB is unaffected — the legitimate operator can still log in.
+	if _, err := m.AuthenticateFrom("victim", "S3cure-Passw0rd!", ipB); err != nil {
+		t.Errorf("ipB should not be locked out by ipA's failures: %v", err)
+	}
+}
+
 // TestCreateFirstAdmin is the regression for VULN-027: only one admin can be
 // bootstrapped; a second call must fail rather than create a duplicate admin.
 func TestCreateFirstAdmin(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes **VULN-026** (Low, CWE-645): brute-force lockout was keyed on **username alone**, so anyone could lock a known operator out from everywhere by sending a handful of bad passwords (targeted-lockout DoS).

- New `AuthenticateFrom(username, password, clientIP)` keys both the lockout buckets **and** the per-attempt serialization gate on `(username, IP)` via `lockoutKey`.
- `handleLogin` passes the request IP; `Authenticate(username, password)` is retained as an IP-less wrapper (delegates with `clientIP=""`).
- A flood from one IP no longer locks out the victim's other IPs.

### Why the tradeoff is acceptable

Per-(username, IP) weakens *distributed* (many-IP) brute force vs. per-username, but that case is now covered by the **12-char minimum password policy** shipped earlier in this remediation (VULN-011). Single-source brute force is still capped at `maxLoginAttempts` per (user, IP).

## Tests

- New `TestLockoutPerUsernameIP`: exhausting attempts from IP-A locks IP-A (even with the correct password) but leaves IP-B able to log in.
- `go build` / `go vet` / `go test ./internal/auth/ ./internal/admin/` ✓ · `go test -race ./internal/auth/` ✓

This was the last remaining finding with a defensible fix; only INFO-3 (default rate-limit threshold — a deployment policy choice) and the unfixable INFO-4 (wordpress.org publishes only SHA1/MD5) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)