### PR TITLE
docs(security): document opt-in global rate limit (INFO-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a `.github/dependabot.yml` was added to keep GitHub Actions, Go modules,
   dashboard npm deps, and Docker base images updated — the maintenance basis for
   safely pinning actions/images (INFO-6, VULN-034).
+- **Global rate-limit guidance (Informational, INFO-3):** the example config now
+  documents an opt-in global per-IP `rate_limit` (DoS backstop for unknown
+  domains + the admin API). The capability already existed; the default stays
+  off (matching nginx/Caddy) so operators tune it to their own traffic.
 
 ## [0.8.6] - 2026-06-25
 

--- a/uwas.example.yaml
+++ b/uwas.example.yaml
@@ -39,6 +39,15 @@ global:
   #   - 172.16.0.0/12
   #   - 192.168.0.0/16
 
+  # Global per-IP rate limit (fallback for unknown domains + admin API).
+  # Disabled by default (like nginx/Caddy). For internet-facing deployments a
+  # conservative global cap is recommended as a DoS backstop — uncomment and
+  # tune to your expected legitimate peak. Per-domain `rate_limit` blocks (see
+  # the domains section) override this for matched hosts.
+  # rate_limit:
+  #   requests: 600       # max requests per window per client IP
+  #   window: 60s         # sliding window
+
   # Connection timeouts
   timeouts:
     read: 30s


### PR DESCRIPTION
## Summary

Addresses **INFO-3**: there was no default global/per-IP rate limit on public web traffic. The capability already exists (`global.rate_limit`, applied when `requests > 0`), but the example config never surfaced it.

This adds a commented, conservative `global.rate_limit` block to `uwas.example.yaml` so operators can enable a DoS backstop for unknown domains + the admin API.

The default stays **off** (matching nginx/Caddy): a forced default would throttle real traffic, and the right threshold depends entirely on a deployment's expected peak. So INFO-3 ships as guidance rather than a behavior change.

Docs-only; no code change. Example config still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)