### PR TITLE
fix: data race on config reload via altSvcHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Data race on config reload:** `altSvcHeader` read `config.Global.HTTP3Enabled`
+  /`HTTPSListen` on the request hot path without a lock, racing the reload's
+  `*s.config = *newCfg` (run on every HTTP/1.1+HTTP/2 response during a SIGHUP
+  reload). It now reads under `configMu.RLock`. Covered by a new concurrent
+  reload-while-serving test under `-race`.
+
 ### Security
 
 - **Privilege escalation (Critical):** non-admin users could over-post the

--- a/internal/server/http3.go
+++ b/internal/server/http3.go
@@ -38,11 +38,17 @@ func (s *Server) startHTTP3() error {
 // This header is added to HTTP/1.1 and HTTP/2 responses so browsers know
 // they can upgrade to HTTP/3.
 func (s *Server) altSvcHeader() string {
-	if !s.config.Global.HTTP3Enabled || s.h3srv == nil {
+	// Read config under the lock: this runs on the request hot path and reload
+	// rewrites *s.config under configMu (data race otherwise).
+	s.configMu.RLock()
+	enabled := s.config.Global.HTTP3Enabled
+	addr := s.config.Global.HTTPSListen
+	s.configMu.RUnlock()
+
+	if !enabled || s.h3srv == nil {
 		return ""
 	}
 	// Extract port from HTTPS listen address
-	addr := s.config.Global.HTTPSListen
 	port := "443"
 	for i := len(addr) - 1; i >= 0; i-- {
 		if addr[i] == ':' {

--- a/internal/server/server_reload_race_test.go
+++ b/internal/server/server_reload_race_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/config"
+)
+
+// TestReloadConcurrentWithRequests runs config reloads concurrently with request
+// serving under -race. It locks in that reload() swaps every per-domain map
+// (rewrite/route/IP-ACL/geo/CORS/WAF/rate-limit/image-opt + htaccess caches)
+// under its lock rather than mutating shared maps in place — the concurrent
+// map-access concern that motivated the (now superseded) PR #18. A regression
+// that reintroduced an unsynchronized swap would trip the race detector here.
+func TestReloadConcurrentWithRequests(t *testing.T) {
+	webroot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(webroot, "index.html"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "uwas.yaml")
+	// A domain exercising every per-domain map rebuilt during reload.
+	cfgYAML := `
+global:
+  worker_count: "1"
+  log_level: error
+  log_format: text
+domains:
+  - host: reload.test
+    type: static
+    root: ` + webroot + `
+    ssl:
+      mode: "off"
+    rewrites:
+      - match: "^/old$"
+        to: "/index.html"
+        status: 302
+    security:
+      geo_block_countries: ["CN"]
+      ip_blacklist: ["10.0.0.1"]
+      waf:
+        enabled: true
+    cors:
+      enabled: true
+      allowed_origins: ["https://x.example"]
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newDispatchTestServer(t, []config.Domain{{Host: "reload.test", Type: "static", Root: webroot}})
+	s.configPath = cfgPath
+	if err := s.reload(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+
+	var wg sync.WaitGroup
+
+	// Reloader: repeatedly swap the per-domain maps.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			if err := s.reload(); err != nil {
+				t.Errorf("reload: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Concurrent readers hitting the per-domain map accessors via dispatch.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", "/index.html", nil)
+				req.Host = "reload.test"
+				s.handleRequest(rec, req)
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

While assessing the (now-superseded) **PR #18** reload-concurrency concern, I found the race is **real and still present on `main`** — and not caught by existing tests because none ran reload concurrently with request serving.

`altSvcHeader()` reads `config.Global.HTTP3Enabled` and `HTTPSListen` on the request **hot path** (it runs for every HTTP/1.1 + HTTP/2 response, via dispatch) **without** holding `configMu`. A SIGHUP config reload does `*s.config = *newCfg` under `configMu.Lock()`, so the two race on every request during a reload.

## Fix

- `altSvcHeader` now snapshots those two fields under `configMu.RLock()`.
- New `TestReloadConcurrentWithRequests` reloads config concurrently with 4 request-serving goroutines; it **fails under `-race`** if an unsynchronized config/map swap is (re)introduced. Verified it catches the original bug (red) and passes after the fix (green).

## Verification

- `go build` / `go vet` ✓
- `go test -race ./internal/server/` ✓ (full package, including the new test)

Note: all other `config.Global` reads in the server package are in `Start()`/startup code that runs once before any reload, so they don't race. This was the only hot-path reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)