### PR TITLE
ci: attach only uwas-* binaries to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,10 +119,13 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - name: Download all artifacts
+      - name: Download release binaries
         uses: actions/download-artifact@v8
         with:
           path: dist
+          # Only the uwas-* binary artifacts — exclude the validate job's
+          # test-output artifact so it isn't attached to the release.
+          pattern: uwas-*
           merge-multiple: true
 
       - name: Upload to release


### PR DESCRIPTION
## Summary

The release `publish` job downloaded **all** workflow artifacts with `merge-multiple: true` — including the `validate` job's `test-output` log — then `gh release upload dist/*` attached everything. As a result every release (including v0.8.7) carried a stray `test-output.log` asset.

Fix: restrict the download to the binary artifacts via `pattern: uwas-*`, so only the platform binaries end up in `dist/` and on the release. The test-output artifact is still produced as a debuggable workflow artifact — it's just no longer a release asset.

Already cleaned the stray asset off the published v0.8.7 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)