### PR TITLE
fix(cache): keep handler-set Content-Encoding on cached entries

### DIFF
--- a/internal/server/capture.go
+++ b/internal/server/capture.go
@@ -20,6 +20,22 @@ type responseCapture struct {
 	body       bytes.Buffer
 	written    bool
 	overflow   bool // true if body exceeded maxCacheableBody
+
+	// handlerEncoding records the Content-Encoding the HANDLER set, sampled
+	// before the first write reaches the compress middleware below us.
+	//
+	// Two different writers can put Content-Encoding on the shared header map:
+	// the handler itself, when it serves an already-encoded body (the static
+	// handler's .br/.gz sibling, a reverse-proxy upstream), and the compress
+	// middleware, when it encodes a plaintext body on the way out. After the
+	// handler returns, the header alone can no longer tell them apart — yet the
+	// distinction decides whether the captured bytes are encoded or not.
+	//
+	// Sampling at the first Write settles it: the compress middleware only sets
+	// the header from inside the delegated write, so whatever is present when
+	// we are called came from the handler.
+	handlerEncoding string
+	sampled         bool
 }
 
 func newResponseCapture(w http.ResponseWriter) *responseCapture {
@@ -43,6 +59,10 @@ func (rc *responseCapture) Write(b []byte) (int, error) {
 	if !rc.written {
 		rc.WriteHeader(http.StatusOK)
 	}
+	if !rc.sampled {
+		rc.sampled = true
+		rc.handlerEncoding = rc.ResponseWriter.Header().Get("Content-Encoding")
+	}
 	if !rc.overflow {
 		if rc.body.Len()+len(b) > maxCacheableBody {
 			rc.overflow = true
@@ -56,6 +76,12 @@ func (rc *responseCapture) Write(b []byte) (int, error) {
 
 func (rc *responseCapture) Header() http.Header {
 	return rc.ResponseWriter.Header()
+}
+
+// bodyIsEncoded reports whether the captured bytes are already content-coded,
+// i.e. the handler declared an encoding for the body it wrote.
+func (rc *responseCapture) bodyIsEncoded() bool {
+	return rc.handlerEncoding != ""
 }
 
 // capturedHeaders snapshots the current response headers. Call after the

--- a/internal/server/server_cache_encoding_test.go
+++ b/internal/server/server_cache_encoding_test.go
@@ -1,0 +1,212 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+
+	"github.com/uwaserver/uwas/internal/config"
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// A handler can emit an ALREADY-ENCODED body and declare it with
+// Content-Encoding: the static handler does this whenever a .br/.gz sibling
+// exists (servePreCompressed), and a reverse-proxy upstream can do the same.
+// The compress middleware honours that declaration and leaves the body alone.
+//
+// The cache capture records what the handler wrote — the encoded bytes — so the
+// stored entry has to keep the encoding that describes them. Dropping it makes
+// every later hit look like a plaintext body to the compress middleware, which
+// encodes it a second time while the response still advertises one layer. The
+// client decodes once and renders compressed bytes as text.
+//
+// These tests pin the invariant from the client's side: a body served from
+// cache decodes in exactly one step, on the first request and every one after.
+
+func newCacheTestChain(t *testing.T, root string) http.Handler {
+	t.Helper()
+	cfg := &config.Config{
+		Global: config.GlobalConfig{
+			WorkerCount: "1",
+			LogLevel:    "error",
+			LogFormat:   "text",
+			// A memory limit is required: with the default 0 the L1 store keeps
+			// nothing, every request is a MISS and these tests pass vacuously.
+			Cache: config.CacheConfig{Enabled: true, MemoryLimit: config.ByteSize(64 << 20)},
+		},
+		Domains: []config.Domain{{
+			Host:  "cache.test",
+			Type:  "static",
+			Root:  root,
+			SSL:   config.SSLConfig{Mode: "off"},
+			Cache: config.DomainCache{Enabled: true, TTL: 60},
+		}},
+	}
+	s := New(cfg, logger.New("error", "text"))
+	t.Cleanup(func() { s.cancel() })
+	return s.buildMiddlewareChain()
+}
+
+func cacheTestGet(t *testing.T, h http.Handler, path, acceptEncoding string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", path, nil)
+	req.Host = "cache.test"
+	req.Header.Set("Accept-Encoding", acceptEncoding)
+	// The bot guard answers an empty User-Agent with 403.
+	req.Header.Set("User-Agent", "uwas-test")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func brotliBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := brotli.NewWriter(&buf)
+	if _, err := w.Write(b); err != nil {
+		t.Fatalf("brotli write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("brotli close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// decodeLayers reports how many brotli passes the body needs to become want.
+// 1 is correct; 2 means the body was encoded twice but declared once.
+func decodeLayers(body, want []byte) int {
+	cur := body
+	for layer := 1; layer <= 3; layer++ {
+		out, err := io.ReadAll(brotli.NewReader(bytes.NewReader(cur)))
+		if err != nil {
+			return -1
+		}
+		if bytes.Equal(out, want) {
+			return layer
+		}
+		cur = out
+	}
+	return -1
+}
+
+// hardToCompress returns printable bytes with enough entropy that their brotli
+// form still exceeds the compress middleware's 1KB threshold — otherwise the
+// second encoding never triggers and the regression hides.
+func hardToCompress(n int) []byte {
+	r := rand.New(rand.NewSource(42))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(32 + r.Intn(95))
+	}
+	return b
+}
+
+func TestCachedPreCompressedBodyKeepsSingleEncoding(t *testing.T) {
+	root := t.TempDir()
+	plain := hardToCompress(8192)
+	encoded := brotliBytes(t, plain)
+	if len(encoded) < 1024 {
+		t.Fatalf("fixture compresses too well (%d bytes); the second encoding would not trigger", len(encoded))
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "data.js"), plain, 0o644); err != nil {
+		t.Fatalf("write data.js: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "data.js.br"), encoded, 0o644); err != nil {
+		t.Fatalf("write data.js.br: %v", err)
+	}
+
+	h := newCacheTestChain(t, root)
+
+	miss := cacheTestGet(t, h, "/data.js", "br")
+	if miss.Code != http.StatusOK {
+		t.Fatalf("miss: status %d want 200", miss.Code)
+	}
+	if enc := miss.Header().Get("Content-Encoding"); enc != "br" {
+		t.Fatalf("miss: Content-Encoding = %q want br", enc)
+	}
+	if n := decodeLayers(miss.Body.Bytes(), plain); n != 1 {
+		t.Fatalf("miss: body needed %d brotli passes, want 1", n)
+	}
+
+	hit := cacheTestGet(t, h, "/data.js", "br")
+	if hit.Code != http.StatusOK {
+		t.Fatalf("hit: status %d want 200", hit.Code)
+	}
+	// Guard against a vacuous pass: without a real cache hit this test says
+	// nothing about the store/replay path.
+	if got := hit.Header().Get("X-Cache"); got != "HIT" {
+		t.Fatalf("second request was not served from cache (X-Cache = %q)", got)
+	}
+	if enc := hit.Header().Get("Content-Encoding"); enc != "br" {
+		t.Fatalf("hit: Content-Encoding = %q want br", enc)
+	}
+	if n := decodeLayers(hit.Body.Bytes(), plain); n != 1 {
+		t.Fatalf("hit: body needed %d brotli passes, want 1 — the cached body was encoded again", n)
+	}
+	if !bytes.Equal(hit.Body.Bytes(), miss.Body.Bytes()) {
+		t.Errorf("hit body differs from miss body (%d vs %d bytes)", hit.Body.Len(), miss.Body.Len())
+	}
+}
+
+// The plaintext path keeps its existing behaviour: the cache stores unencoded
+// bytes and the compress middleware encodes them once per hit.
+func TestCachedPlainBodyStillEncodedOncePerHit(t *testing.T) {
+	root := t.TempDir()
+	plain := []byte(strings.Repeat("plain body, encoded by the middleware. ", 64))
+	if err := os.WriteFile(filepath.Join(root, "page.html"), plain, 0o644); err != nil {
+		t.Fatalf("write page.html: %v", err)
+	}
+
+	h := newCacheTestChain(t, root)
+
+	miss := cacheTestGet(t, h, "/page.html", "br")
+	if miss.Code != http.StatusOK {
+		t.Fatalf("miss: status %d want 200", miss.Code)
+	}
+	if n := decodeLayers(miss.Body.Bytes(), plain); n != 1 {
+		t.Fatalf("miss: body needed %d brotli passes, want 1", n)
+	}
+
+	hit := cacheTestGet(t, h, "/page.html", "br")
+	if got := hit.Header().Get("X-Cache"); got != "HIT" {
+		t.Fatalf("second request was not served from cache (X-Cache = %q)", got)
+	}
+	if enc := hit.Header().Get("Content-Encoding"); enc != "br" {
+		t.Fatalf("hit: Content-Encoding = %q want br", enc)
+	}
+	if n := decodeLayers(hit.Body.Bytes(), plain); n != 1 {
+		t.Fatalf("hit: body needed %d brotli passes, want 1", n)
+	}
+}
+
+// A client that accepts no encoding must still receive a readable body. The
+// pre-compressed variant is only selected when the request advertises support
+// for it, so the entry stored for this client is plaintext.
+func TestCachedBodyReadableWithoutAcceptEncoding(t *testing.T) {
+	root := t.TempDir()
+	plain := []byte(strings.Repeat("identity clients read this verbatim. ", 64))
+	if err := os.WriteFile(filepath.Join(root, "page.html"), plain, 0o644); err != nil {
+		t.Fatalf("write page.html: %v", err)
+	}
+
+	h := newCacheTestChain(t, root)
+
+	for _, label := range []string{"miss", "hit"} {
+		rec := cacheTestGet(t, h, "/page.html", "identity")
+		if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+			t.Fatalf("%s: Content-Encoding = %q want empty", label, enc)
+		}
+		if !bytes.Equal(rec.Body.Bytes(), plain) {
+			t.Fatalf("%s: body was not served verbatim (%d bytes)", label, rec.Body.Len())
+		}
+	}
+}

--- a/internal/server/server_dispatch.go
+++ b/internal/server/server_dispatch.go
@@ -601,16 +601,31 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 		// Store the response in cache if it is cacheable and not too large.
 		hdrs := capture.capturedHeaders()
-		// The capture records the pre-compression body, but the global compress
-		// middleware sits below it and, for bodies >= 1KB, sets Content-Encoding:
-		// br|gzip (and drops Content-Length) on the shared header map before we
-		// snapshot it. Storing that encoding header with the uncompressed body
-		// would make every cache hit serve plaintext mislabeled as br/gzip (the
-		// compress writer skips re-compressing when Content-Encoding is already
-		// set), so the client fails to decode. Strip both: the cached body is
-		// canonical uncompressed bytes, and the compress middleware re-derives
-		// encoding/length on each hit.
-		hdrs.Del("Content-Encoding")
+		// Content-Encoding on the snapshot can have two very different meanings,
+		// and storing the wrong one corrupts every subsequent hit.
+		//
+		// When the compress middleware encoded a plaintext body on the way out,
+		// the captured bytes are NOT encoded: keeping the header would serve
+		// plaintext mislabeled as br/gzip, because the compress writer skips a
+		// body that already declares an encoding. Strip it and let compress
+		// re-derive encoding and length on each hit.
+		//
+		// When the HANDLER served an already-encoded body (the static handler's
+		// .br/.gz sibling, a reverse-proxy upstream), the captured bytes ARE
+		// encoded. Stripping the header there hands compress what looks like a
+		// plaintext body, so every hit gets compressed a second time while the
+		// response still advertises a single layer — the client decodes once and
+		// is left holding compressed bytes. Keep the header so the encoding
+		// travels with the body it describes.
+		//
+		// Content-Length is dropped either way: compress removes it when it
+		// encodes, and a stored length can go stale (ESI assembly rewrites the
+		// body on hit).
+		if capture.bodyIsEncoded() {
+			hdrs.Set("Content-Encoding", capture.handlerEncoding)
+		} else {
+			hdrs.Del("Content-Encoding")
+		}
 		hdrs.Del("Content-Length")
 		if !capture.overflow && cache.IsCacheable(r, ctx.Response.StatusCode(), hdrs) {
 			ttl := time.Duration(domain.Cache.TTL) * time.Second


### PR DESCRIPTION
## Problem

A handler can serve an already-encoded body and declare it with `Content-Encoding`. The static handler does this whenever a `.br`/`.gz` sibling exists (`servePreCompressed`), and a reverse-proxy upstream can do the same. The compress middleware honours that declaration and leaves such a body alone.

The cache capture records what the handler wrote — the encoded bytes — but the store path stripped `Content-Encoding` unconditionally:

```go
hdrs.Del("Content-Encoding")
hdrs.Del("Content-Length")
```

The entry therefore held an **encoded body advertised as plaintext**. On the next hit it was replayed without the header, so the compress middleware saw what looked like plaintext and encoded it a second time — while the response still advertised a single layer. The client decodes once and renders compressed bytes as text.

## Impact

Observed on a production site running v0.8.9. Every cache hit on the homepage returned ~2500 `U+FFFD` characters; the page was unreadable. 14 consecutive requests, 14 corrupted responses.

The failure only ever appeared on hits, which made it look intermittent:

| Request | Result |
|---|---|
| `/?nocache=123` (unique URL, MISS) | clean |
| `Accept-Encoding: identity` | clean |
| cache disabled | clean |
| cache enabled, same URL again | **corrupted** |

Layer-by-layer decode of a corrupted response:

```
content-encoding : br
layer 0 (raw)    : 5863 bytes  — binary   [0b 71 8b 1b]
layer 1 (brotli) : 5859 bytes  — binary   [1b ea 6f 44]   ← still compressed
layer 2 (brotli) : 28651 bytes — <!DOCTYPE html ✓
```

28651 bytes matches the `Accept-Encoding: identity` body exactly.

## Why the strip has to stay

The strip is correct for the common case: when the compress middleware encodes a plaintext body it sets `Content-Encoding` on the shared header map, and keeping that header would serve unencoded bytes mislabeled as br/gzip. After the handler returns, the header alone cannot say which writer set it.

## Fix

`responseCapture` samples `Content-Encoding` at its **first `Write`**, before the write is delegated downstream. The compress middleware only sets the header from inside that delegated call, so whatever is present at sampling time came from the handler.

The store path then keeps the encoding when the captured body is encoded, and strips it otherwise. `Content-Length` is still dropped in both cases: compress removes it when it encodes, and a stored length can go stale (ESI assembly rewrites the body on hit).

## Verification

```
Without fix:  request 1 MISS 6798 bytes decode-layers=1
              request 2 HIT  6802 bytes decode-layers=2   ← bug
With fix:     request 2 HIT  6798 bytes decode-layers=1   ← identical to MISS
```

New tests in `internal/server/server_cache_encoding_test.go` check the invariant from the client's side — a body served from cache decodes in exactly one step:

- **pre-compressed file** — single encoding on miss and on hit, byte-identical bodies. Fails without this change: `hit: body needed 2 brotli passes, want 1`
- **plaintext file** — still encoded once per hit (no regression)
- **`Accept-Encoding: identity`** — served verbatim

### A note on the tests

Both cache tests assert `X-Cache: HIT` on the second request. Without that assertion they **pass vacuously**: the default `MemoryLimit` of 0 keeps nothing, so every request is a MISS and the store/replay path is never exercised. My first attempt at these tests passed for exactly that reason.

There was no existing test covering cache and compression together — which is likely why this survived.

`go build`, `go vet` and the touched packages (`server`, `middleware`, `cache`, `handler/...`) are clean. Unrelated failures in `internal/admin` and backup tests are pre-existing on macOS (missing `/bin/true`, Docker, mysql client) and reproduce on an unmodified checkout.
