### PR TITLE
ci: pass go package lists as arrays so actionlint is clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,19 +68,19 @@ jobs:
 
       - name: Lint (go vet + staticcheck)
         run: |
-          GO_PACKAGES="$(go list ./... | grep -v '/node_modules/')"
-          go vet $GO_PACKAGES
-          staticcheck $GO_PACKAGES
+          mapfile -t GO_PACKAGES < <(go list ./... | grep -v '/node_modules/')
+          go vet "${GO_PACKAGES[@]}"
+          staticcheck "${GO_PACKAGES[@]}"
 
       - name: Vulnerability scan
         run: |
-          GO_PACKAGES="$(go list ./... | grep -v '/node_modules/')"
-          govulncheck $GO_PACKAGES
+          mapfile -t GO_PACKAGES < <(go list ./... | grep -v '/node_modules/')
+          govulncheck "${GO_PACKAGES[@]}"
 
       - name: Test
         run: |
-          GO_PACKAGES="$(go list ./... | grep -v '/node_modules/')"
-          go test -v -count=1 -timeout 600s $GO_PACKAGES 2>&1 | tee /tmp/test-output.log
+          mapfile -t GO_PACKAGES < <(go list ./... | grep -v '/node_modules/')
+          go test -v -count=1 -timeout 600s "${GO_PACKAGES[@]}" 2>&1 | tee /tmp/test-output.log
 
       - name: Upload test output
         if: always()
@@ -108,7 +108,7 @@ jobs:
           docker run --detach --rm --name uwas-race-mysql \
             -e MARIADB_ROOT_PASSWORD=root -e MARIADB_ROOT_HOST=% \
             -p 127.0.0.1:3306:3306 uwas-mariadb:ci
-          for attempt in {1..60}; do
+          for _ in {1..60}; do
             if docker exec uwas-race-mysql \
               healthcheck.sh --connect --innodb_initialized; then
               exit 0
@@ -123,8 +123,8 @@ jobs:
 
       - name: Race detector
         run: |
-          GO_PACKAGES="$(go list ./... | grep -v '/node_modules/')"
-          go test -race -count=1 -timeout 900s $GO_PACKAGES
+          mapfile -t GO_PACKAGES < <(go list ./... | grep -v '/node_modules/')
+          go test -race -count=1 -timeout 900s "${GO_PACKAGES[@]}"
         env:
           UWAS_DB_HOST: "127.0.0.1"
           UWAS_DB_PORT: "3306"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,18 @@ jobs:
 
       - name: Vet
         run: |
-          GO_PACKAGES="$(go list ./... | grep -v '/node_modules/')"
-          go vet $GO_PACKAGES
+          mapfile -t GO_PACKAGES < <(go list ./... | grep -v '/node_modules/')
+          go vet "${GO_PACKAGES[@]}"
 
       - name: Vulnerability scan
         run: |
-          GO_PACKAGES="$(go list ./... | grep -v '/node_modules/')"
-          go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 $GO_PACKAGES
+          mapfile -t GO_PACKAGES < <(go list ./... | grep -v '/node_modules/')
+          go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 "${GO_PACKAGES[@]}"
 
       - name: Test
         run: |
-          GO_PACKAGES="$(go list ./... | grep -v '/node_modules/')"
-          go test -v -count=1 -timeout 600s -p 1 $GO_PACKAGES 2>&1 | tee /tmp/test-output.log
+          mapfile -t GO_PACKAGES < <(go list ./... | grep -v '/node_modules/')
+          go test -v -count=1 -timeout 600s -p 1 "${GO_PACKAGES[@]}" 2>&1 | tee /tmp/test-output.log
 
       - name: Upload test output
         if: always()


### PR DESCRIPTION
## Problem

The **Lint workflows** step has been failing on `main`. Because it runs first in the `test` job, every step after it is skipped:

```
✓ Install actionlint
✗ Lint workflows              ← stops here
- Lint (go vet + staticcheck)   skipped
- Vulnerability scan            skipped
- Test                          skipped
```

So CI reports red without ever compiling or testing the code. A change can land with broken tests and nothing would catch it.

## Findings

actionlint reported nine shellcheck issues across the two workflows:

| Rule | Count | What |
|---|---|---|
| SC2086 | 7 | `$GO_PACKAGES` expanded unquoted |
| SC2034 | 1 | loop counter `attempt` assigned but never read |

## Fix

The unquoted expansions were **deliberate** — the variable holds a newline-separated package list that has to word-split. But suppressing the warning would leave the split fragile: a package path containing a space or a glob character would break the command.

Reading the list into an array keeps the intent and removes the fragility:

```diff
-GO_PACKAGES="$(go list ./... | grep -v '/node_modules/')"
-go test -v -count=1 -timeout 600s $GO_PACKAGES
+mapfile -t GO_PACKAGES < <(go list ./... | grep -v '/node_modules/')
+go test -v -count=1 -timeout 600s "${GO_PACKAGES[@]}"
```

The MariaDB readiness loop only needs to run a fixed number of times, so its counter becomes `_`.

## Verification

Run locally with the same actionlint version CI installs (v1.7.12), with shellcheck present so the shell checks actually execute:

```
before: 9 shellcheck findings
after : 0, exit code 0
```

No workflow logic changed — same commands, same order, same environment. The only behavioural difference is that the steps after the lint gate can now run.
