### PR TITLE
chore: bump go directive to 1.26.6 to clear stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uwaserver/uwas
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/andybalholm/brotli v1.2.2


### PR DESCRIPTION
## Problem

`govulncheck` reports **seven standard-library vulnerabilities** reachable from this codebase. Every one is fixed in `go1.26.6`; `go.mod` pins `go 1.26.5`.

Several are reachable from request-serving paths, so this is not a theoretical exposure for a web server:

| Advisory | Package | Reached from |
|---|---|---|
| GO-2026-5972 | `encoding/asn1` — unbounded recursion | `acme.init` → `x509.CreateCertificateRequest` |
| GO-2026-5942 | `net` — SVCB/HTTPS RR parse panic | `dnschecker.Check` → `net.LookupCNAME` |
| GO-2026-5026 | `net/http` — idna punycode rejection | `proxy.Handler.Serve` → `http.Transport.RoundTrip` |

plus four more in `crypto/tls`, `encoding/xml`, `net/url` and `net/http`.

## Fix

One line. All five `setup-go` steps use `go-version-file: go.mod`, so the directive covers the CI job, the race job and both release builds.

```diff
-go 1.26.5
+go 1.26.6
```

No dependency versions move.

## Verification

Local run with `GOTOOLCHAIN=go1.26.6`, same package list CI uses:

```
govulncheck: 7 vulnerabilities → 0 ("No vulnerabilities found")
go build ./...            ok
go vet                    ok
internal/server           ok
internal/cache            ok
internal/middleware       ok
internal/handler/...      ok
internal/tls, tls/acme    ok
```

## Context

This surfaced after #50 fixed the workflow lint gate. The `Vulnerability scan` step had been skipped for as long as `Lint workflows` was failing, so these findings were invisible. Together the two PRs let the `test` job reach `go test` for the first time in a while.
