### PR TITLE
fix(deps): bump nanoid to 3.3.18 in dashboard and docs lockfiles

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -2545,9 +2545,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/web/dashboard/package-lock.json
+++ b/web/dashboard/package-lock.json
@@ -3745,9 +3745,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Problem

`npm audit --audit-level=moderate` fails in both the **dashboard** and **docs** jobs, so neither reaches its lint or build step:

```
nanoid  <3.3.18
Severity: high
nanoid: custom generators can loop indefinitely when size is zero
https://github.com/advisories/GHSA-2v37-7h3g-55p8
```

## Fix

`nanoid` is a transitive dependency in both projects; `npm audit fix` resolves it within the existing ranges.

```diff
-"version": "3.3.16",
+"version": "3.3.18",
```

Only the two lockfiles change — no `package.json` constraint moves, and nothing else in either tree is touched.

## Verification

Run locally in both `web/dashboard` and `docs/site`:

| Step | Result |
|---|---|
| `npm audit --audit-level=moderate` | found 0 vulnerabilities |
| `npm run lint` | 0 errors (57 pre-existing warnings in the dashboard, unchanged) |
| `npm run build` | succeeds |
