### PR TITLE
fix(docker): refresh stale tzdata pin and align builder with go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26.6-alpine3.24@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
 
 RUN apk add --no-cache git=2.54.0-r0
 
@@ -30,7 +30,7 @@ FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec4
 RUN apk add --no-cache \
     ca-certificates=20260611-r0 \
     libcap=2.78-r0 \
-    tzdata=2026b-r0
+    tzdata=2026c-r0
 
 COPY --from=builder /uwas /usr/local/bin/uwas
 


### PR DESCRIPTION
## Problem

The `docker-integration` job fails at image build:

```
RUN apk add --no-cache ca-certificates=20260611-r0 libcap=2.78-r0 tzdata=2026b-r0
ERROR: unable to select packages:
  tzdata-2026c-r0:
    breaks: world[tzdata=2026b-r0]
```

The runtime stage pins exact apk versions while the base image is pinned by digest. The image is immutable, but `apk` resolves against the **live** Alpine repository — so a package that moves on breaks the build even though nothing in this repo changed.

Checked against `alpine:3.24` today:

| Package | Pinned | Current |
|---|---|---|
| ca-certificates | 20260611-r0 | 20260611-r0 ✓ |
| libcap | 2.78-r0 | 2.78-r0 ✓ |
| git | 2.54.0-r0 | 2.54.0-r0 ✓ |
| **tzdata** | **2026b-r0** | **2026c-r0** ✗ |

Only `tzdata` moved.

## Also in this change

The builder image goes to `golang:1.26.6-alpine3.24` (with its digest) so it matches the `go` directive in `go.mod` after #51. Left at 1.26.5 the build would download a second toolchain on every run to satisfy go.mod — wasteful, and a needless network dependency mid-build.

## Why it went unnoticed

`docker-integration` only runs after `test` passes. While the workflow lint gate was failing (#50), this job was skipped on every run, so the pin quietly rotted.

## Verification

Run locally:

```
docker build                    succeeds
make -s -C test/docker test     ALL TESTS PASSED: 47/47
hadolint                        exit 0, no findings
```

hadolint was run with the same pinned image digest and the same file list CI uses, so the exact-pin policy (DL3018) is still satisfied.

## A note for later

This will rot again the next time an Alpine package moves. Options if you want to stop it recurring: let Dependabot/Renovate watch the Dockerfile, or relax the pins to `>=` where the policy allows. Out of scope here — this PR just gets CI moving again.
