### PR TITLE
ci: time-boxed trivy exception for openssl CVE with no upstream fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,10 @@ jobs:
             uwas-wordpress-php:7.0.1 uwas-wordpress-cli:2.12.0; do
             docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
               -v /tmp/trivy-cache:/root/.cache \
+              -v "$PWD/.trivyignore.yaml:/.trivyignore.yaml:ro" \
               aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
               image --exit-code 1 --severity HIGH,CRITICAL \
+              --ignorefile /.trivyignore.yaml \
               --scanners vuln,secret "$image"
           done
 

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,21 @@
+# Süreli istisnalar. Her kaydın bir gerekçesi ve son kullanma tarihi olmalı;
+# tarih geçince Trivy istisnayı yok sayar ve bulgu yeniden görünür.
+#
+# Buraya yalnız YUKARI AKIŞTA DÜZELTMESİ OLMAYAN bulgular girer. Düzeltmesi
+# yayımlanmış bir paket için doğru hamle burayı büyütmek değil, paketi
+# yükseltmektir.
+vulnerabilities:
+  - id: CVE-2026-14456
+    # openssl: QUIC sunucusunda sınırsız bellek büyümesiyle hizmet reddi.
+    # libcrypto3 / libssl3 3.5.7-r0, düzeltme 3.5.8-r0.
+    #
+    # 27.08.2026 itibarıyla 3.5.8-r0 Alpine'ın HİÇBİR dalında yok — 3.24 de
+    # edge de 3.5.7-r0 veriyor. Yani yükseltilecek bir paket yok; imaj
+    # yeniden derlense de sonuç değişmiyor.
+    #
+    # Etkisi bu imaj için sınırlı: uwas QUIC'i kendi Go yığınıyla konuşur
+    # (quic-go), openssl'in QUIC sunucu tarafını kullanmaz.
+    #
+    # Tarih geldiğinde: Alpine 3.24'te libcrypto3 3.5.8-r0 çıktıysa temel
+    # imajı tazeleyip bu kaydı silin.
+    expired_at: 2026-10-15


### PR DESCRIPTION
## Problem

`Scan runtime images` fails on:

```
libcrypto3  CVE-2026-14456  HIGH  3.5.7-r0 → fixed in 3.5.8-r0
libssl3     CVE-2026-14456  HIGH  3.5.7-r0 → fixed in 3.5.8-r0
openssl: Denial of Service via unbounded memory growth in QUIC server
```

## There is nothing to upgrade

Checked on 27.08.2026:

| Source | libcrypto3 |
|---|---|
| pinned base digest | 3.5.7-r0 |
| current `alpine:3.24` tag | 3.5.7-r0 — **same digest as the pin** |
| `alpine:edge` | 3.5.7-r0 |

The patched package has not been published to any Alpine branch. Refreshing the base image or the pins changes nothing.

## What this PR does

It suppresses the finding **with an expiry**, so the decision resurfaces on its own:

```yaml
vulnerabilities:
  - id: CVE-2026-14456
    expired_at: 2026-10-15
```

Trivy stops honouring the entry after that date and the finding returns — no one has to remember.

The scan step also had to change: the trivy container previously had no access to the repo, so an ignore file alone would have had no effect. It now mounts the file and passes `--ignorefile`.

## Exposure

Looks limited for this image: uwas speaks QUIC through its own Go stack (quic-go), not openssl's QUIC server implementation. **I'd like a second opinion from someone who knows the deployment better** — if you disagree, the alternative is leaving this job red until Alpine publishes 3.5.8-r0.

## Verification

Against the built image, with the same pinned trivy digest CI uses:

| Case | Result |
|---|---|
| no ignore file | exit 1, CVE reported |
| valid exception | exit 0, "vulnerabilities have been suppressed" |
| `expired_at` in the past | exit 1, finding returns |

`actionlint` passes on the modified workflow.

Depends on #53 — without the tzdata fix the job never reaches this step.
