### PR TITLE
test(admin): make WP duplicate-install test set up its own precondition

### DIFF
--- a/internal/admin/admin_coverage2_test.go
+++ b/internal/admin/admin_coverage2_test.go
@@ -4320,12 +4320,29 @@ func TestWPInstallWithDomain(t *testing.T) {
 }
 
 func TestWPInstallDuplicateRunning(t *testing.T) {
+	// The handler answers 409 while an install is in flight. That state lives on
+	// the package-level wpHandler, so this test used to depend on some earlier
+	// test having left an install running — order- and timing-dependent, and it
+	// failed under -race when the earlier goroutine had already finished.
+	//
+	// The precondition is now set up here: the first request marks an install
+	// running, the second is the duplicate under test.
 	s := testServer()
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/v1/wordpress/install", strings.NewReader(`{"domain":"test.com","web_root":"/tmp/test"}`))
-	s.handleWPInstall(rec, req)
-	if rec.Code != 409 {
-		t.Errorf("status = %d, want 409", rec.Code)
+	root := t.TempDir()
+	body := func() *strings.Reader {
+		return strings.NewReader(`{"domain":"test.com","web_root":"` + filepath.ToSlash(root) + `"}`)
+	}
+
+	first := httptest.NewRecorder()
+	s.handleWPInstall(first, httptest.NewRequest("POST", "/api/v1/wordpress/install", body()))
+	if first.Code != 200 {
+		t.Fatalf("first install: status = %d, want 200, body: %s", first.Code, first.Body.String())
+	}
+
+	second := httptest.NewRecorder()
+	s.handleWPInstall(second, httptest.NewRequest("POST", "/api/v1/wordpress/install", body()))
+	if second.Code != 409 {
+		t.Errorf("duplicate install: status = %d, want 409, body: %s", second.Code, second.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestWPInstallDuplicateRunning` fails the **race** job:

```
--- FAIL: TestWPInstallDuplicateRunning
    admin_coverage2_test.go:4328: status = 200, want 409
```

## Diagnosis

The handler answers 409 while an install is in flight:

```go
h.mu.Lock()
if h.result != nil && h.result.Status == "running" {
    → 409 "WordPress install already in progress"
}
h.result = &wp.InstallResult{Status: "running", ...}
h.mu.Unlock()

go func() { result := wp.Install(req); h.result = &result }()
```

That state lives on the **package-level** `wpHandler`. The test asserted 409 without ever starting an install, so it depended on:

1. some earlier test in the package having called Install, and
2. that install's goroutine still being in flight when this test ran

Under `-race` the timing shifts and the precondition is gone, so the handler takes the normal path and returns 200.

## Fix

The test now creates the state it asserts on — first request marks an install running, second is the duplicate under test. Between two synchronous handler calls the background `wp.Install` cannot have completed, so the second request reliably sees `running`.

It also writes into `t.TempDir()` instead of the shared absolute path `/tmp/test`, so runs no longer influence each other through the filesystem.

## Honest limitation

**I could not reproduce the CI failure locally.** The old test passes here both in isolation and in the full package, on macOS under `-race`. The reasoning above comes from reading the handler, not from a local red-to-green.

What *is* verifiable locally:

| Check | Result |
|---|---|
| new test, 12 runs under `-race` | 12/12 pass |
| full `internal/admin` under `-race`, with change | 2 failures |
| full `internal/admin` under `-race`, without change | the **same** 2 failures |

Those two (`TestGitAuthEnv_WithToken`, `TestHandleCloudflareTunnelStart_ConnectedNoRunner`) are macOS-specific and pre-existing — missing `/bin/true` and no cloudflared runner.

If you know the suite better and think the flake has a different cause, say so — this change stands on its own as removing an order dependence, but I'd rather not claim it fixes something it doesn't.
