### PR TITLE
fix(config): accept the apps:// upstream scheme

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -739,6 +739,18 @@ func validateProxyUpstreamAddress(prefix, address string, errs *[]string) {
 	}
 	switch strings.ToLower(parsed.Scheme) {
 	case "http", "https", "ws", "wss":
+		// Network upstreams: the address is dialled as written.
+	case "apps":
+		// Managed app upstream. The host part is an app NAME, not a network
+		// address — resolveAppsUpstream turns it into the live 127.0.0.1:port
+		// the supervisor assigned, at pool-build time (see
+		// internal/server/apps_upstream.go). The dashboard writes this form
+		// whenever an app is picked for a proxy domain.
+		//
+		// The metadata guard below is skipped for the same reason: it compares
+		// against link-local addresses, and an app named like one still routes
+		// through the supervisor, never to the metadata service.
+		return
 	default:
 		*errs = append(*errs, fmt.Sprintf("%s: unsupported URL scheme %q", prefix, parsed.Scheme))
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -880,3 +880,66 @@ func TestValidateMinimalConfig(t *testing.T) {
 	cfg := minimalValidConfig()
 	expectNoValidationError(t, cfg)
 }
+
+// --- apps:// upstream scheme ---
+
+// The dashboard writes `apps://<name>` whenever an app is picked for a proxy
+// domain, and resolveAppsUpstream turns that into the supervisor's live
+// 127.0.0.1:port at pool-build time. Rejecting the scheme here made the server
+// refuse to start on a configuration it had written itself.
+func TestValidateProxyUpstreams_AppsSchemeAccepted(t *testing.T) {
+	for _, address := range []string{
+		"apps://dgn-git",
+		"apps://dgn-git:3001",
+		"apps://my-app/health",
+	} {
+		cfg := minimalValidConfig()
+		cfg.Domains = []Domain{proxyDomain([]Upstream{{Address: address, Weight: 1}})}
+		t.Run(address, func(t *testing.T) {
+			expectNoValidationError(t, cfg)
+		})
+	}
+}
+
+// An app name that happens to look like a link-local address still routes
+// through the supervisor, so the metadata guard must not fire on it. The guard
+// stays in force for real network upstreams.
+func TestValidateProxyUpstreams_AppsSchemeSkipsMetadataGuard(t *testing.T) {
+	cfg := minimalValidConfig()
+	cfg.Domains = []Domain{proxyDomain([]Upstream{{Address: "apps://169.254.169.254", Weight: 1}})}
+	expectNoValidationError(t, cfg)
+
+	cfg = minimalValidConfig()
+	cfg.Domains = []Domain{proxyDomain([]Upstream{{Address: "http://169.254.169.254", Weight: 1}})}
+	expectValidationError(t, cfg, "cloud metadata endpoint blocked")
+}
+
+// Only the schemes the proxy can actually consume are allowed. h2c and grpc
+// appear in comments as future work but nothing resolves them today, so a
+// config using them must still be rejected rather than failing at request time.
+func TestValidateProxyUpstreams_UnknownSchemesStillRejected(t *testing.T) {
+	for _, address := range []string{
+		"app://dgn-git", // singular: a plausible typo for apps://
+		"h2c://127.0.0.1:3000",
+		"grpc://127.0.0.1:3000",
+	} {
+		cfg := minimalValidConfig()
+		cfg.Domains = []Domain{proxyDomain([]Upstream{{Address: address, Weight: 1}})}
+		t.Run(address, func(t *testing.T) {
+			expectValidationError(t, cfg, "unsupported URL scheme")
+		})
+	}
+
+	// A scheme with no host never reaches the scheme check — it is rejected
+	// earlier as an unusable URL. Asserted separately so the message is right.
+	cfg := minimalValidConfig()
+	cfg.Domains = []Domain{proxyDomain([]Upstream{{Address: "file:///etc/passwd", Weight: 1}})}
+	expectValidationError(t, cfg, "invalid URL")
+}
+
+// apps:// with no name has no host for the resolver to look up.
+func TestValidateProxyUpstreams_AppsSchemeRequiresName(t *testing.T) {
+	cfg := minimalValidConfig()
+	cfg.Domains = []Domain{proxyDomain([]Upstream{{Address: "apps://", Weight: 1}})}
+	expectValidationError(t, cfg, "invalid URL")
+}


### PR DESCRIPTION
## Problem

Upstream validation added in 0.8.10 accepts only `http`, `https`, `ws`, `wss`. But `apps://` is a **first-class scheme in this project**:

- `resolveAppsUpstream` translates `apps://<name>` into the live `127.0.0.1:port` the supervisor assigned (`internal/server/apps_upstream.go`)
- the dashboard writes exactly that form whenever an app is picked for a proxy domain (`Domains.tsx:1102`)
- the domain health check special-cases it (`handlers_domain_health.go:281`)

So the server refuses to start on a configuration **its own dashboard wrote**. And it is not a warning — validation aborts the load, so one app-backed domain takes down every other domain on the host.

## Reported from a production install

Picking an app in the panel wrote `apps://<name>`; the next restart failed:

```
uwas serve: load config: validate config: config validation failed:
  domains[14].proxy.upstreams[0]: unsupported URL scheme "apps"
```

The operator had 15+ domains. All of them were down until the config was hand-edited.

## Fix

`apps` joins the accepted schemes.

The cloud-metadata guard is skipped for it: the guard compares against link-local addresses, but the host part here is an **app name**, and a name that happens to look like `169.254.169.254` still routes through the supervisor rather than to the metadata service. The guard stays in force for network upstreams — asserted by a test.

`h2c` and `grpc` appear in a comment as future work but nothing resolves them today, so they stay rejected. Failing at load beats failing on every request. `apps://` with no name is still rejected as an unusable URL.

## Verification

With a config carrying the exact address from the report:

```
released v0.8.11  →  unsupported URL scheme "apps"
with this change  →  Configuration valid: 1 domains
```

Tests fail without the change (`apps://dgn-git`, `apps://dgn-git:3001`) and pass with it. `go vet`, `internal/config` and `internal/server` all clean.

## Worth considering separately

A single unusable upstream aborting the whole config load is harsh for a server hosting many domains. Disabling the affected domain with a loud warning, while the rest come up, would have turned this outage into a log line. Out of scope here — this PR just stops the false rejection.
