### PR TITLE
test(server): fix flaky signal tests racing signal.Notify

### DIFF
--- a/internal/server/server_gap_cov3_test.go
+++ b/internal/server/server_gap_cov3_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -26,6 +27,14 @@ func TestHandleSignalsSIGINT(t *testing.T) {
 	log := logger.New("error", "text")
 	s := New(cfg, log)
 
+	// Trap SIGINT for the whole process before any is sent. signal.Notify is
+	// process-wide, and without a registration in place the default action for
+	// SIGINT terminates the test binary — the send below races the handler's
+	// own Notify call.
+	guard := make(chan os.Signal, 1)
+	signal.Notify(guard, syscall.SIGINT)
+	defer signal.Stop(guard)
+
 	// Override the wg so handleSignals uses ours
 	s.wg.Add(1)
 	done := make(chan struct{})
@@ -34,14 +43,28 @@ func TestHandleSignalsSIGINT(t *testing.T) {
 		close(done)
 	}()
 
-	// Send SIGINT
-	syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	// The goroutine registers its channel inside handleSignals, so a single
+	// send can land before it is listening and be delivered only to `guard`.
+	// Go does not expose "is this channel registered yet", so the signal is
+	// re-sent until the handler reacts.
+	deadline := time.After(5 * time.Second)
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
 
-	select {
-	case <-done:
-		// handleSignals returned after cancel()
-	case <-time.After(2 * time.Second):
-		t.Fatal("handleSignals did not return after SIGINT")
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("send SIGINT: %v", err)
+	}
+	for {
+		select {
+		case <-done:
+			return // handleSignals returned after cancel()
+		case <-tick.C:
+			if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+				t.Fatalf("send SIGINT: %v", err)
+			}
+		case <-deadline:
+			t.Fatal("handleSignals did not return after SIGINT")
+		}
 	}
 }
 
@@ -74,6 +97,14 @@ func TestHandleSignalsSIGHUPWithoutConfigPath(t *testing.T) {
 	}
 	s := New(cfg, log)
 
+	// Trap SIGHUP for the process before sending one. The default action for
+	// SIGHUP terminates the binary, and the send below races the handler's own
+	// Notify call — with no registration in place a mistimed signal would take
+	// the whole test run down.
+	guard := make(chan os.Signal, 1)
+	signal.Notify(guard, syscall.SIGHUP)
+	defer signal.Stop(guard)
+
 	s.wg.Add(1)
 	done := make(chan struct{})
 	go func() {
@@ -81,11 +112,17 @@ func TestHandleSignalsSIGHUPWithoutConfigPath(t *testing.T) {
 		close(done)
 	}()
 
-	// Send SIGHUP — config path is empty, reload will log an error
-	syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
-
-	// Wait a moment for the signal to be processed, then cancel
-	time.Sleep(100 * time.Millisecond)
+	// Send SIGHUP — config path is empty, reload will log an error.
+	// Re-sent over a short window because the handler may not have registered
+	// its channel yet. This test does not assert the signal was received (it
+	// only requires handleSignals to return on cancellation), so a lost signal
+	// costs coverage of the reload branch rather than failing the run.
+	for i := 0; i < 5; i++ {
+		if err := syscall.Kill(syscall.Getpid(), syscall.SIGHUP); err != nil {
+			t.Fatalf("send SIGHUP: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 	s.cancel()
 
 	select {


### PR DESCRIPTION
## Problem

`TestHandleSignalsSIGINT` sends `SIGINT` immediately after spawning `handleSignals`, but `handleSignals` calls `signal.Notify(sigCh, ...)` **inside** that goroutine. When the signal wins the race it is never delivered to the handler's channel and the test times out after 2s.

There is a second, nastier hazard: if no `signal.Notify` registration exists anywhere in the process when the signal lands, the default action for SIGINT terminates the test binary.

## Fix

Register a process-wide guard channel *before* signalling, then re-send `SIGINT` on a 20ms ticker until `handleSignals` returns. The guard prevents the default action; the ticker closes the registration race.

`TestHandleSignalsSIGHUPWithoutConfigPath` has the same send-before-`Notify` shape and gets the same treatment. Note it never asserted the signal was received — it only requires `handleSignals` to return on cancellation — so a lost SIGHUP cost coverage of the reload branch rather than failing the run. The default SIGHUP action would still have killed the binary, which is what the guard addresses there.

## Measurement

| | before | after |
|---|---|---|
| macOS, `-race` | **0/6 passed** | **15/15 passed** |
| both signal tests together, `-race` | — | 10/10 passed |
| full `./internal/server/` package, `-race` | — | ok, 13.8s |

## Scope

This race is **pre-existing on `main`** and unrelated to any recent change. On CI Linux it flakes intermittently rather than failing deterministically — it failed one run on #59 and passed on the rerun. On macOS it reproduces 100% of the time. The fix removes the race in both environments.

Worth watching the `race` job specifically on this PR.