### PR TITLE
fix(server): re-resolve apps:// upstreams after starting apps at boot

### DIFF
--- a/internal/server/apps_upstream.go
+++ b/internal/server/apps_upstream.go
@@ -69,3 +69,26 @@ func splitAppsTarget(target string) (string, int) {
 	}
 	return strings.TrimSpace(name), port
 }
+
+// startRegisteredApps launches every enabled app and then rebuilds the
+// proxy pools that point at them.
+//
+// The rebuild is not optional. New() builds the pools while every app is
+// still stopped, so ListenAddrForPort returns "" for each `apps://<name>`
+// upstream and resolveAppsUpstream substitutes the http://127.0.0.1:0
+// placeholder. StartAll() then launches the apps and assigns them real
+// ports, but the pools already hold :0 and nothing re-resolves them —
+// so every request to such a domain fails with ECONNREFUSED and the
+// operator sees "502 Bad Gateway — upstream refused connection" for the
+// entire process lifetime. The only escape was an unrelated config
+// reload, which happens to call rebuildProxyPools.
+//
+// Rebuilding here is safe at boot: no listener is accepting yet, so
+// ResetTransports has no in-flight traffic to disturb.
+func (s *Server) startRegisteredApps() {
+	if s.appsMgr == nil {
+		return
+	}
+	s.appsMgr.StartAll()
+	s.rebuildProxyPools(s.config.Domains)
+}

--- a/internal/server/apps_upstream_boot_test.go
+++ b/internal/server/apps_upstream_boot_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/apps"
+	"github.com/uwaserver/uwas/internal/config"
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// bootServerWithApp builds a server whose only domain proxies to
+// `apps://demo`, plus a registered-but-not-yet-started app named demo.
+// This is the boot state: pools already built, apps still down.
+func bootServerWithApp(t *testing.T) (*Server, *apps.Manager) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Global: config.GlobalConfig{
+			WorkerCount: "1", LogLevel: "error", LogFormat: "text",
+			HTTPListen: ":18390", HTTPSListen: ":18391",
+		},
+		Domains: []config.Domain{{
+			Host: "app.test",
+			Type: "proxy",
+			Root: dir,
+			SSL:  config.SSLConfig{Mode: "off"},
+			Proxy: config.ProxyConfig{
+				Upstreams: []config.Upstream{{Address: "apps://demo", Weight: 1}},
+			},
+		}},
+	}
+	s := New(cfg, logger.New("error", "text"))
+
+	mgr := apps.NewManager(apps.NewStore(filepath.Join(dir, "apps.d")), nil)
+	s.appsMgr = mgr
+	if err := mgr.Register(&apps.App{
+		Name:    "demo",
+		Runtime: apps.RuntimeCustom,
+		Command: "sleep 30",
+		WorkDir: t.TempDir(),
+	}); err != nil {
+		t.Fatalf("register demo app: %v", err)
+	}
+	t.Cleanup(mgr.StopAll)
+	return s, mgr
+}
+
+func poolHost(t *testing.T, s *Server, host string) string {
+	t.Helper()
+	pool, ok := s.proxyPools[host]
+	if !ok {
+		t.Fatalf("no proxy pool for %s", host)
+	}
+	backends := pool.All()
+	if len(backends) != 1 {
+		t.Fatalf("pool has %d backends, want 1", len(backends))
+	}
+	return backends[0].URL.Host
+}
+
+// The bug: starting the apps without rebuilding the pools leaves every
+// apps:// upstream pinned to the 127.0.0.1:0 placeholder that New()
+// resolved while the app was still down. Requests then fail with
+// ECONNREFUSED — "502 Bad Gateway, upstream refused connection" — even
+// though the app is running perfectly well.
+func TestAppsUpstreamStaysPlaceholderWhenPoolsNotRebuilt(t *testing.T) {
+	s, mgr := bootServerWithApp(t)
+
+	if got := poolHost(t, s, "app.test"); got != "127.0.0.1:0" {
+		t.Fatalf("pre-start pool host = %q, want the 127.0.0.1:0 placeholder", got)
+	}
+
+	mgr.StartAll() // the old boot path: start apps, never re-resolve
+
+	// Guard against a vacuous pass: if the app never came up, the stale
+	// placeholder below would be correct rather than a bug.
+	live := mgr.ListenAddrForPort("demo", 0)
+	if live == "" {
+		t.Fatal("demo app did not start — test cannot distinguish stale from correct")
+	}
+
+	if got := poolHost(t, s, "app.test"); got != "127.0.0.1:0" {
+		t.Fatalf("pool host = %q; expected it to still hold the stale placeholder", got)
+	}
+	t.Logf("app is live at %s but the pool still points at 127.0.0.1:0", live)
+}
+
+// The fix: startRegisteredApps re-resolves the pools after StartAll, so
+// the upstream tracks the port the supervisor actually assigned.
+func TestStartRegisteredAppsReResolvesUpstreams(t *testing.T) {
+	s, mgr := bootServerWithApp(t)
+
+	s.startRegisteredApps()
+
+	live := mgr.ListenAddrForPort("demo", 0)
+	if live == "" {
+		t.Fatal("demo app did not start")
+	}
+	if got := poolHost(t, s, "app.test"); got != live {
+		t.Fatalf("pool host = %q, want the live app address %q", got, live)
+	}
+}
+
+// A nil supervisor must not panic or disturb existing pools.
+func TestStartRegisteredAppsNilManager(t *testing.T) {
+	s, _ := bootServerWithApp(t)
+	s.appsMgr = nil
+	s.startRegisteredApps()
+	if got := poolHost(t, s, "app.test"); got != "127.0.0.1:0" {
+		t.Fatalf("pool host = %q, want unchanged placeholder", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -753,10 +753,9 @@ func (s *Server) Start() error {
 		s.logger.Warn("failed to write pid file", "error", err)
 	}
 
-	// Start every registered app from /etc/uwas/apps.d/.
-	if s.appsMgr != nil {
-		s.appsMgr.StartAll()
-	}
+	// Start every registered app from /etc/uwas/apps.d/, then re-resolve
+	// the proxy pools that reference them.
+	s.startRegisteredApps()
 
 	s.tlsMgr.AllowSelfSigned = true
 	s.tlsMgr.LoadExistingCerts()


### PR DESCRIPTION
## Symptom

A domain proxying to a standalone app returns **502 Bad Gateway — upstream refused connection** after a UWAS restart, even though the app itself is running. Saving anything in the dashboard makes it start working again, so the failure looks intermittent and self-healing.

## Root cause — a boot ordering bug

| where | what happens |
|---|---|
| `New()` : `server.go:513` | proxy pools are built. Every app is still **stopped**, so `ListenAddrForPort` returns `""` and `resolveAppsUpstream` substitutes the `http://127.0.0.1:0` placeholder. |
| `Start()` : `server.go:758` | `StartAll()` launches the apps on their real ports. |
| after that | **nothing re-resolves the pools.** |

The upstream stays pinned to `127.0.0.1:0` for the whole process lifetime. Connecting to port 0 fails with `ECONNREFUSED`, which the proxy renders as the 502 above.

The escape hatch was accidental: any config reload calls `rebuildProxyPools`, so an unrelated dashboard save would fix it until the next restart.

## Fix

`StartAll()` moves into `startRegisteredApps()`, which starts the apps and then rebuilds the pools. Safe at boot — no listener is accepting yet, so `ResetTransports` has no in-flight traffic to disturb.

## Tests

Three tests in `internal/server/apps_upstream_boot_test.go`:

- **`TestAppsUpstreamStaysPlaceholderWhenPoolsNotRebuilt`** pins the bug shape. It asserts the app is genuinely live *before* checking the stale placeholder, so it cannot pass vacuously if the app fails to start. It logs the discrepancy directly:
  ```
  app is live at 127.0.0.1:3001 but the pool still points at 127.0.0.1:0
  ```
- **`TestStartRegisteredAppsReResolvesUpstreams`** asserts the pool tracks the port the supervisor actually assigned.
- **`TestStartRegisteredAppsNilManager`** covers the nil-supervisor path.

`go vet` clean; `./internal/server/ -race` passes in 15s; full suite green apart from `TestGitAuthEnv_WithToken`, which fails identically on `main` under macOS because it hardcodes `/bin/true` (that path is `/usr/bin/true` on Darwin).