### PR TITLE
fix(admin): stop reporting healthy app-backed domains as down

### DIFF
--- a/internal/admin/domain_health_app_test.go
+++ b/internal/admin/domain_health_app_test.go
@@ -1,0 +1,200 @@
+package admin
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/apps"
+	"github.com/uwaserver/uwas/internal/config"
+)
+
+// appBackedHealthFixture stands up a real HTTP server on loopback, then
+// registers an app the supervisor reports as listening on that exact
+// port, and points a proxy domain at it via an apps:// upstream.
+func appBackedHealthFixture(t *testing.T, code int) (*Server, string) {
+	t.Helper()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+	}))
+	t.Cleanup(backend.Close)
+
+	_, portStr, err := net.SplitHostPort(strings.TrimPrefix(backend.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split backend addr: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse backend port: %v", err)
+	}
+
+	mgr := apps.NewManager(apps.NewStore(filepath.Join(t.TempDir(), "apps.d")), nil)
+	// RuntimeCustom skips the start-time port availability check, so the
+	// supervisor keeps the port our backend is already listening on.
+	if err := mgr.Register(&apps.App{
+		Name:    "demo",
+		Runtime: apps.RuntimeCustom,
+		Command: "sleep 30",
+		Port:    port,
+		WorkDir: t.TempDir(),
+	}); err != nil {
+		t.Fatalf("register app: %v", err)
+	}
+	if err := mgr.Start("demo"); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+	t.Cleanup(mgr.StopAll)
+
+	if got := mgr.ListenAddr("demo"); got != "127.0.0.1:"+portStr {
+		t.Fatalf("supervisor reports %q, want 127.0.0.1:%s", got, portStr)
+	}
+
+	s := testServer()
+	s.SetAppsManager(mgr)
+	s.config.Domains = []config.Domain{{
+		Host: "app.example.com",
+		Type: "proxy",
+		SSL:  config.SSLConfig{Mode: "off"},
+		Proxy: config.ProxyConfig{
+			Upstreams: []config.Upstream{{Address: "apps://demo", Weight: 1}},
+		},
+	}}
+	return s, "127.0.0.1:" + portStr
+}
+
+// healthItemFor picks the record for one hostname. A domain yields a
+// record per hostname (the host plus its www. alias), so tests must
+// select rather than assume a single item.
+func healthItemFor(t *testing.T, s *Server, host string) struct {
+	Host   string `json:"host"`
+	Target string `json:"target"`
+	Status string `json:"status"`
+	Code   int    `json:"code"`
+	Error  string `json:"error"`
+} {
+	t.Helper()
+	for _, it := range healthItems(t, s) {
+		if it.Host == host {
+			return it
+		}
+	}
+	t.Fatalf("no health record for %q", host)
+	panic("unreachable")
+}
+
+func healthItems(t *testing.T, s *Server) []struct {
+	Host   string `json:"host"`
+	Target string `json:"target"`
+	Status string `json:"status"`
+	Code   int    `json:"code"`
+	Error  string `json:"error"`
+} {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, httptest.NewRequest("GET", "/api/v1/domains/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Items []struct {
+			Host   string `json:"host"`
+			Target string `json:"target"`
+			Status string `json:"status"`
+			Code   int    `json:"code"`
+			Error  string `json:"error"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	return body.Items
+}
+
+// A domain backed by a healthy apps:// upstream must report "up". The
+// probe target is the loopback address the supervisor assigned, which
+// the SSRF guard is built to refuse — applying that guard here marked
+// every app-backed domain "down" no matter how healthy the app was, and
+// the dashboard rendered the result as "Inactive".
+func TestDomainHealthAppUpstreamReportsUp(t *testing.T) {
+	s, addr := appBackedHealthFixture(t, http.StatusOK)
+
+	got := healthItemFor(t, s, "app.example.com")
+
+	if got.Target != "http://"+addr+"/" {
+		t.Fatalf("probe target = %q, want the supervisor's loopback address http://%s/", got.Target, addr)
+	}
+	if strings.Contains(got.Error, "blocked") {
+		t.Fatalf("probe was blocked by the SSRF guard: %q", got.Error)
+	}
+	if got.Status != "up" || got.Code != http.StatusOK {
+		t.Fatalf("status = %q code = %d, want up/200 (error: %q)", got.Status, got.Code, got.Error)
+	}
+}
+
+// A failing app must still report a failure — the fix must not turn the
+// check into something that always says "up".
+func TestDomainHealthAppUpstreamReportsErrorOn5xx(t *testing.T) {
+	s, _ := appBackedHealthFixture(t, http.StatusBadGateway)
+
+	got := healthItemFor(t, s, "app.example.com")
+	if got.Status != "error" || got.Code != http.StatusBadGateway {
+		t.Fatalf("status = %q code = %d, want error/502", got.Status, got.Code)
+	}
+}
+
+// Domains that are not app-backed keep the SSRF guard: a loopback Host
+// must still be refused, so the fix cannot be used to probe internal
+// addresses by pointing a domain at them.
+func TestDomainHealthNonAppLoopbackStillBlocked(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	s := testServer()
+	s.config.Domains = []config.Domain{{
+		Host: strings.TrimPrefix(backend.URL, "http://"),
+		Type: "static",
+		SSL:  config.SSLConfig{Mode: "off"},
+	}}
+
+	got := healthItemFor(t, s, strings.TrimPrefix(backend.URL, "http://"))
+	if got.Status != "down" || !strings.Contains(got.Error, "blocked") {
+		t.Fatalf("status = %q error = %q, want down + blocked", got.Status, got.Error)
+	}
+}
+
+// The apps:// path reports "down" with a clear reason when the app is
+// registered but not running.
+func TestDomainHealthAppUpstreamNotListening(t *testing.T) {
+	mgr := apps.NewManager(apps.NewStore(filepath.Join(t.TempDir(), "apps.d")), nil)
+	if err := mgr.Register(&apps.App{
+		Name:    "stopped",
+		Runtime: apps.RuntimeCustom,
+		Command: "./run",
+	}); err != nil {
+		t.Fatalf("register app: %v", err)
+	}
+
+	s := testServer()
+	s.SetAppsManager(mgr)
+	s.config.Domains = []config.Domain{{
+		Host: "stopped.example.com",
+		Type: "proxy",
+		SSL:  config.SSLConfig{Mode: "off"},
+		Proxy: config.ProxyConfig{
+			Upstreams: []config.Upstream{{Address: "apps://stopped", Weight: 1}},
+		},
+	}}
+
+	got := healthItemFor(t, s, "stopped.example.com")
+	if got.Status != "down" || !strings.Contains(got.Error, "not listening") {
+		t.Fatalf("status = %q error = %q, want down + not listening", got.Status, got.Error)
+	}
+}

--- a/internal/admin/handlers_domain_health.go
+++ b/internal/admin/handlers_domain_health.go
@@ -196,6 +196,24 @@ func (s *Server) handleDomainHealth(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	// Domains backed by an apps:// upstream are probed at the loopback
+	// address the supervisor assigned them, which the guarded client above
+	// is built to refuse. That address is not attacker-influenced: it is
+	// always 127.0.0.1 on a port this process allocated or verified the app
+	// exposes, so it gets its own client with a plain dialer.
+	internalClient := &http.Client{
+		Timeout: 5 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			DialContext: (&net.Dialer{
+				Timeout: 5 * time.Second,
+			}).DialContext,
+		},
+	}
+
 	var wg sync.WaitGroup
 	for i, target := range targets {
 		wg.Add(1)
@@ -207,7 +225,7 @@ func (s *Server) handleDomainHealth(w http.ResponseWriter, r *http.Request) {
 				ParentHost: target.ParentHost,
 				Kind:       target.Kind,
 			}
-			url, appErr := s.domainHealthURL(dom)
+			url, appErr, internal := s.domainHealthURL(dom)
 			hr.Target = url
 			if appErr != "" {
 				hr.Status = "down"
@@ -215,9 +233,17 @@ func (s *Server) handleDomainHealth(w http.ResponseWriter, r *http.Request) {
 				results[idx] = hr
 				return
 			}
-			// Reject targets that resolve to internal/metadata addresses before
-			// dialing (defense-in-depth alongside SafeDialControl above).
-			if err := config.IsWebhookURLSafe(url); err != nil {
+
+			probe := client
+			if internal {
+				// Address came from the apps supervisor, not from the
+				// domain's Host field — the SSRF guard below would reject
+				// its own loopback target and report every app-backed
+				// domain as down.
+				probe = internalClient
+			} else if err := config.IsWebhookURLSafe(url); err != nil {
+				// Reject targets that resolve to internal/metadata addresses
+				// before dialing (defense-in-depth alongside SafeDialControl).
 				hr.Status = "down"
 				hr.Error = "blocked: " + err.Error()
 				results[idx] = hr
@@ -225,7 +251,7 @@ func (s *Server) handleDomainHealth(w http.ResponseWriter, r *http.Request) {
 			}
 
 			start := time.Now()
-			resp, err := client.Get(url)
+			resp, err := probe.Get(url)
 			hr.Ms = time.Since(start).Milliseconds()
 
 			if err != nil {
@@ -261,15 +287,19 @@ func (s *Server) handleDomainHealth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) domainHealthURL(dom config.Domain) (string, string) {
+// domainHealthURL returns the URL to probe, an error string when an
+// apps:// upstream is configured but not listening, and whether the URL
+// is an internally-resolved loopback address rather than the domain's
+// public hostname. Callers must not run the SSRF guard on internal URLs.
+func (s *Server) domainHealthURL(dom config.Domain) (string, string, bool) {
 	if appURL, appErr := s.appDomainHealthURL(dom); appURL != "" || appErr != "" {
-		return appURL, appErr
+		return appURL, appErr, appURL != ""
 	}
 	scheme := "http"
 	if dom.SSL.Mode == "auto" || dom.SSL.Mode == "manual" {
 		scheme = "https"
 	}
-	return fmt.Sprintf("%s://%s/", scheme, dom.Host), ""
+	return fmt.Sprintf("%s://%s/", scheme, dom.Host), "", false
 }
 
 func (s *Server) appDomainHealthURL(dom config.Domain) (string, string) {


### PR DESCRIPTION
## Symptom

In the dashboard's domain list, a domain proxied to a standalone app always shows **Inactive / down**, even when the app is running and serving traffic normally.

## Root cause — the endpoint blocks its own probe target

For a domain whose upstream is `apps://<name>`, `domainHealthURL` resolves the target through the supervisor and returns the loopback address it assigned:

```
http://127.0.0.1:3001/
```

The handler then ran that URL through `config.IsWebhookURLSafe` — an SSRF guard whose entire purpose is to refuse loopback and private addresses:

```
http://127.0.0.1:3001/  ->  URL host "127.0.0.1" is a blocked loopback address (SSRF)
```

So the check rejected its own target and recorded `status: "down"`. The dashboard renders that as "Inactive" because `StatusDot` is driven by `health.status === 'up'` (`web/dashboard/src/pages/Domains.tsx:1499`). Both labels the user sees come from this one value.

## Why the guard is right for other domains and wrong here

For an ordinary domain the probe target is built from the domain's `Host` field, which an operator can point at anything — `169.254.169.254`, an internal service, whatever. Without the guard this admin endpoint is a semi-blind internal port scanner, which is exactly what it was added for.

The `apps://` path is different in kind: the address is not read from configuration at all. It is resolved by this process — always `127.0.0.1`, on a port the supervisor either allocated itself or verified the app exposes (`processExposesPort`). There is no operator-controlled component to abuse.

## Fix

`domainHealthURL` now also reports whether the target was internally resolved. Internal targets skip the guard and are probed with a separate client whose dialer omits `SafeDialControl`. Everything else keeps the guard and the original guarded client untouched.

## Tests

Four tests in `internal/admin/domain_health_app_test.go`, covering both directions so the fix cannot degenerate into "always up":

| test | asserts |
|---|---|
| `...AppUpstreamReportsUp` | app-backed domain serving 200 → `up`, target is the supervisor's loopback address, not blocked |
| `...AppUpstreamReportsErrorOn5xx` | app serving 502 → still `error` |
| `...NonAppLoopbackStillBlocked` | non-app domain pointed at loopback → still `down` + `blocked` |
| `...AppUpstreamNotListening` | registered but stopped app → `down` + "not listening" |

The first two **fail without this change** (verified by reverting the source file and re-running); the two guard tests pass either way, which is the point.

`go vet` clean. On macOS the admin package also fails `TestGitAuthEnv_WithToken` (hardcodes `/bin/true`, which is `/usr/bin/true` on Darwin) and `TestHandleCloudflareTunnelStart_ConnectedNoRunner` — both fail identically on `main` and are environmental.