### PR TITLE
fix(cache): honour rule ttl and global.cache.default_ttl

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -351,6 +351,18 @@ func Validate(cfg *Config) error {
 			if rule.TTL < 0 {
 				errs = append(errs, fmt.Sprintf("%s.cache.rules[%d]: ttl must be >= 0, got %d", prefix, j, rule.TTL))
 			}
+			// match is a REGEX, not a glob. An uncompilable pattern used to be
+			// swallowed at request time (matchPath returns false), so a rule
+			// written as "*.html" silently never matched and the operator got
+			// no bypass, no Cache-Control and no ttl — with nothing to explain
+			// why. Report it here instead.
+			if rule.Match != "" {
+				if _, err := regexp.Compile(rule.Match); err != nil {
+					errs = append(errs, fmt.Sprintf(
+						"%s.cache.rules[%d].match: not a valid regular expression (%v) — this field is a regex, not a glob; use \\.html$ rather than *.html",
+						prefix, j, err))
+				}
+			}
 		}
 	}
 

--- a/internal/config/validate_branches_test.go
+++ b/internal/config/validate_branches_test.go
@@ -97,3 +97,37 @@ func TestStripBOM(t *testing.T) {
 		t.Errorf("short data altered: %q", got)
 	}
 }
+
+// cache.rules[].match is a REGEX, not a glob. An uncompilable pattern used to
+// be swallowed at request time — matchPath compiles it, fails, and returns
+// false — so a rule written the glob way silently never matched: no bypass, no
+// Cache-Control, no ttl, and nothing in the logs to explain it.
+func TestValidate_CacheRuleMatchMustCompile(t *testing.T) {
+	cfg := minimalValidConfig()
+	cfg.Domains[0].Cache = DomainCache{
+		Enabled: true,
+		Rules:   []CacheRule{{Match: "*.html", TTL: 60}},
+	}
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("glob-shaped pattern should be rejected")
+	}
+	// The message has to say what to write instead; "invalid regexp" alone
+	// leaves the operator guessing why their glob is wrong.
+	if !strings.Contains(err.Error(), "regex, not a glob") {
+		t.Errorf("error should explain the field is a regex, got: %v", err)
+	}
+}
+
+func TestValidate_CacheRuleValidRegexAccepted(t *testing.T) {
+	cfg := minimalValidConfig()
+	cfg.Domains[0].Cache = DomainCache{
+		Enabled: true,
+		Rules:   []CacheRule{{Match: `\.html$`, TTL: 60}},
+	}
+
+	if err := Validate(cfg); err != nil {
+		t.Errorf("valid regex rejected: %v", err)
+	}
+}

--- a/internal/server/server_cache_ttl_test.go
+++ b/internal/server/server_cache_ttl_test.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/uwaserver/uwas/internal/config"
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// NOT: cache.rules[].match bir REGEX'tir, glob değil. "*.html" geçersiz bir
+// regex olduğu için matchPath sessizce false döner — testler de bu yüzden
+// önce eşleşmiyordu. Desen doğrulaması validate.go'ya eklendi.
+//
+// Two cache settings were dead configuration: a cache rule's `ttl` and
+// `global.cache.default_ttl`. The store path hardcoded a 60 second fallback and
+// read neither, so an operator could set them in the dashboard, see them echoed
+// back by the API, and get no change in behaviour.
+//
+// These tests assert the resolved TTL that actually lands on the cache entry,
+// so they fail if the settings go back to being ignored.
+
+func TestCacheTTLForPrecedence(t *testing.T) {
+	cases := []struct {
+		ad       string
+		rule     int
+		domain   int
+		global   int
+		beklenen time.Duration
+	}{
+		{"kural her şeyi ezer", 30, 120, 3600, 30 * time.Second},
+		{"kural yoksa domain", 0, 120, 3600, 120 * time.Second},
+		{"domain yoksa global", 0, 0, 3600, 3600 * time.Second},
+		{"hiçbiri yoksa bir dakika", 0, 0, 0, 60 * time.Second},
+		{"negatif değerler yok sayılır", -5, -1, 900, 900 * time.Second},
+	}
+
+	for _, c := range cases {
+		t.Run(c.ad, func(t *testing.T) {
+			got := cacheTTLFor(c.rule, c.domain, c.global)
+			if got != c.beklenen {
+				t.Errorf("cacheTTLFor(%d, %d, %d) = %v, want %v",
+					c.rule, c.domain, c.global, got, c.beklenen)
+			}
+		})
+	}
+}
+
+// ttlFixture serves one static file through the full middleware chain and
+// returns the server so the test can inspect what landed in the cache.
+func ttlFixture(t *testing.T, globalDefaultTTL, domainTTL int, rules []config.CacheRule) (*Server, http.Handler) {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "index.html"),
+		[]byte("<!doctype html><title>ttl</title>"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cfg := &config.Config{
+		Global: config.GlobalConfig{
+			WorkerCount: "1",
+			LogLevel:    "error",
+			LogFormat:   "text",
+			// A memory limit is required: with the default 0 the L1 store keeps
+			// nothing, every request is a MISS and nothing is ever stored — the
+			// assertions below would pass vacuously.
+			Cache: config.CacheConfig{
+				Enabled:     true,
+				MemoryLimit: config.ByteSize(64 << 20),
+				DefaultTTL:  globalDefaultTTL,
+			},
+		},
+		Domains: []config.Domain{{
+			Host:  "ttl.test",
+			Type:  "static",
+			Root:  root,
+			SSL:   config.SSLConfig{Mode: "off"},
+			Cache: config.DomainCache{Enabled: true, TTL: domainTTL, Rules: rules},
+		}},
+	}
+
+	s := New(cfg, logger.New("error", "text"))
+	t.Cleanup(func() { s.cancel() })
+	return s, s.buildMiddlewareChain()
+}
+
+// istekYap sends one request through the chain. The bot guard answers an
+// empty User-Agent with 403, so it must be set.
+func istekYap(h http.Handler, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = "ttl.test"
+	req.Header.Set("User-Agent", "uwas-test")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// saklananTTL issues one request and returns the TTL of the entry it stored.
+func saklananTTL(t *testing.T, s *Server, h http.Handler, path string) time.Duration {
+	t.Helper()
+
+	rec := istekYap(h, path)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s durum %d döndü, 200 bekleniyordu", path, rec.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = "ttl.test"
+	entry, _ := s.cache.Get(req)
+	if entry == nil {
+		t.Fatalf("%s önbelleğe yazılmadı — test boşa geçemez", path)
+	}
+	return entry.TTL
+}
+
+func TestCacheEntryUsesGlobalDefaultTTL(t *testing.T) {
+	// Domain leaves ttl unset; global.cache.default_ttl must apply.
+	s, h := ttlFixture(t, 1800, 0, nil)
+
+	if got := saklananTTL(t, s, h, "/index.html"); got != 1800*time.Second {
+		t.Errorf("saklanan TTL = %v, want 30m (global.cache.default_ttl)", got)
+	}
+}
+
+func TestCacheEntryUsesDomainTTLOverGlobal(t *testing.T) {
+	s, h := ttlFixture(t, 1800, 300, nil)
+
+	if got := saklananTTL(t, s, h, "/index.html"); got != 300*time.Second {
+		t.Errorf("saklanan TTL = %v, want 5m (domain cache.ttl)", got)
+	}
+}
+
+func TestCacheEntryUsesMatchingRuleTTL(t *testing.T) {
+	// The rule matches and must win over both the domain and the global value.
+	s, h := ttlFixture(t, 1800, 300, []config.CacheRule{
+		{Match: `\.html$`, TTL: 45},
+	})
+
+	if got := saklananTTL(t, s, h, "/index.html"); got != 45*time.Second {
+		t.Errorf("saklanan TTL = %v, want 45s (eşleşen kural)", got)
+	}
+}
+
+func TestCacheEntryIgnoresNonMatchingRuleTTL(t *testing.T) {
+	// A rule that does not match must leave the domain value in place —
+	// otherwise the rule TTL would leak onto every path.
+	s, h := ttlFixture(t, 1800, 300, []config.CacheRule{
+		{Match: `\.css$`, TTL: 45},
+	})
+
+	if got := saklananTTL(t, s, h, "/index.html"); got != 300*time.Second {
+		t.Errorf("saklanan TTL = %v, want 5m (kural eşleşmiyor)", got)
+	}
+}
+
+func TestCacheBypassRuleStillWins(t *testing.T) {
+	// Adding a ttl to the rule loop must not disturb bypass: a bypassed path
+	// is not cached at all.
+	s, h := ttlFixture(t, 1800, 300, []config.CacheRule{
+		{Match: `\.html$`, Bypass: true, TTL: 45},
+	})
+
+	if rec := istekYap(h, "/index.html"); rec.Code != http.StatusOK {
+		t.Fatalf("durum %d döndü, 200 bekleniyordu", rec.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/index.html", nil)
+	req.Host = "ttl.test"
+	if entry, _ := s.cache.Get(req); entry != nil {
+		t.Errorf("bypass edilen yol önbelleğe yazıldı (TTL %v)", entry.TTL)
+	}
+}

--- a/internal/server/server_dispatch.go
+++ b/internal/server/server_dispatch.go
@@ -498,8 +498,12 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 			cacheEnabled = false
 		}
 	}
+	// TTL of the last matching cache rule, in seconds. Zero means no rule set
+	// one and the domain/global value applies. Rules are evaluated in order and
+	// the last match wins, matching how Cache-Control is applied just below.
+	ruleTTL := 0
 	if cacheEnabled {
-		// Check per-domain cache bypass rules + set Cache-Control from rules
+		// Check per-domain cache bypass rules + set Cache-Control and TTL from rules
 		for _, rule := range domain.Cache.Rules {
 			if matchPath(r.URL.Path, rule.Match) {
 				if rule.Bypass {
@@ -508,6 +512,9 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 				}
 				if rule.CacheControl != "" {
 					ctx.Response.Header().Set("Cache-Control", rule.CacheControl)
+				}
+				if rule.TTL > 0 {
+					ruleTTL = rule.TTL
 				}
 			}
 		}
@@ -618,10 +625,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		// hit brotli-compresses the already-brotli body while advertising one
 		// Content-Encoding layer.
 		if !capture.overflow && !capture.upstreamEncoded && cache.IsCacheable(r, ctx.Response.StatusCode(), hdrs) {
-			ttl := time.Duration(domain.Cache.TTL) * time.Second
-			if ttl <= 0 {
-				ttl = 60 * time.Second
-			}
+			ttl := cacheTTLFor(ruleTTL, domain.Cache.TTL, s.config.Global.Cache.DefaultTTL)
 			capturedBody := capture.body.Bytes()
 			isESI := domain.Cache.ESI && s.esiProcessor != nil &&
 				strings.Contains(hdrs.Get("Content-Type"), "text/html") &&
@@ -899,4 +903,26 @@ func (s *Server) handleRedirect(ctx *router.RequestContext, domain *config.Domai
 		status = http.StatusMovedPermanently
 	}
 	http.Redirect(ctx.Response, ctx.Request, target, status)
+}
+
+// cacheTTLFor resolves how long a cache entry should live, in precedence order:
+// the matching cache rule's ttl, then the domain's cache.ttl, then
+// global.cache.default_ttl, and finally a one minute floor.
+//
+// Both the rule ttl and the global default used to be dead configuration: the
+// store path hardcoded a 60 second fallback and read neither. Operators could
+// set them in the dashboard, see them echoed back by the API, and get no
+// change in behaviour.
+//
+// NOTE: this changes the effective TTL of existing installs. A domain that
+// leaves cache.ttl at 0 previously got 60s; it now gets global.cache.default_ttl,
+// which defaults to 3600. Operators relying on the old implicit minute should
+// set cache.ttl explicitly.
+func cacheTTLFor(ruleTTL, domainTTL, globalDefaultTTL int) time.Duration {
+	for _, secs := range []int{ruleTTL, domainTTL, globalDefaultTTL} {
+		if secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return 60 * time.Second
 }


### PR DESCRIPTION
## Two settings did nothing

The store path read neither `global.cache.default_ttl` nor a cache rule's `ttl`, and hardcoded a 60 second fallback:

```go
ttl := time.Duration(domain.Cache.TTL) * time.Second
if ttl <= 0 {
    ttl = 60 * time.Second
}
```

`global.cache.default_ttl` is defined in the config struct, defaulted to 3600 in `defaults.go`, validated in `validate.go`, and exposed in the Settings UI — and never read at runtime. A cache rule's `ttl` is parsed, validated, and returned by the admin API, but the rule loop read only `Bypass` and `CacheControl`.

So an operator sets a value, sees it echoed back, and nothing changes. That is worse than not offering the setting.

## Fix

`cacheTTLFor()` resolves the TTL in precedence order: **matching rule → domain `cache.ttl` → `global.cache.default_ttl` → one minute floor**. Rules are evaluated in order and the last match wins, matching how `Cache-Control` is already applied in the same loop.

## ⚠️ Behaviour change

A domain that leaves `cache.ttl` at `0` previously got **60s** and now gets `global.cache.default_ttl`, which **defaults to 3600**. Operators relying on the old implicit minute should set `cache.ttl` explicitly. Worth calling out in the release notes.

## Second finding: `match` is a regex, not a glob

`matchPath` compiles `rule.Match` as a regular expression. An uncompilable pattern is swallowed — compile fails, the function returns `false` — so a rule written the glob way (`*.html`) **silently never matches**: no bypass, no `Cache-Control`, no ttl, and nothing in the logs to explain why.

It is now rejected at config validation with a message that says what to write instead:

```
domains[0].cache.rules[0].match: not a valid regular expression (...) —
this field is a regex, not a glob; use \.html$ rather than *.html
```

This caught me while writing the tests for this very PR, which is roughly the point.

## Tests

Assertions are made against the TTL that actually lands on the cache entry, not against the helper alone. Each fixture fails loudly if nothing was cached rather than passing vacuously — two separate things silently empty the cache here: the L1 store keeps nothing without a `MemoryLimit`, and the bot guard answers an empty `User-Agent` with 403.

Sharpness measured by reverting only the resolution line and re-running:

| test | before | after |
|---|---|---|
| global default applies | 1m0s instead of 30m ❌ | ✅ |
| matching rule ttl applies | 5m0s instead of 45s ❌ | ✅ |
| domain ttl wins over global | ✅ (control) | ✅ |
| non-matching rule ignored | ✅ (control) | ✅ |
| bypass rule still bypasses | ✅ (control) | ✅ |
| glob pattern rejected | ❌ | ✅ |

`go vet` clean; `internal/server` and `internal/config` pass with `-race`.

Unrelated pre-existing failures on macOS, identical on `main`: `TestGitAuthEnv_WithToken` (hardcodes `/bin/true`), `TestHandleCloudflareTunnelStart_ConnectedNoRunner`, `TestRestoreBackupWithDomainsDir`.