### PR TITLE
fix(backup): sembolik bağlantı üzerinden erişilen köke restore sessizce atlıyordu

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -368,7 +368,11 @@ func (m *BackupManager) RestoreBackup(name, provider string) error {
 			var ok bool
 			outPath, ok = safeRestorePath(domainsDir, rel)
 			if !ok {
-				continue // path traversal or symlink escape attempt
+				// Say so. A silently dropped entry means the operator is
+				// told the restore succeeded while files are missing.
+				m.logger.Warn("backup restore: entry rejected as unsafe, not restored",
+					"name", hdr.Name)
+				continue
 			}
 		case strings.HasPrefix(hdr.Name, "certs/"):
 			if certsDir == "" {
@@ -381,7 +385,11 @@ func (m *BackupManager) RestoreBackup(name, provider string) error {
 			var ok bool
 			outPath, ok = safeRestorePath(certsDir, rel)
 			if !ok {
-				continue // path traversal or symlink escape attempt
+				// Say so. A silently dropped entry means the operator is
+				// told the restore succeeded while files are missing.
+				m.logger.Warn("backup restore: entry rejected as unsafe, not restored",
+					"name", hdr.Name)
+				continue
 			}
 		case strings.HasPrefix(hdr.Name, "sites/"):
 			// Restore domain web content to web root
@@ -395,7 +403,11 @@ func (m *BackupManager) RestoreBackup(name, provider string) error {
 			var ok bool
 			outPath, ok = safeRestorePath(webRoot, rel)
 			if !ok {
-				continue // path traversal or symlink escape attempt
+				// Say so. A silently dropped entry means the operator is
+				// told the restore succeeded while files are missing.
+				m.logger.Warn("backup restore: entry rejected as unsafe, not restored",
+					"name", hdr.Name)
+				continue
 			}
 		case hdr.Name == "databases/all-databases.sql" || hdr.Name == "databases/native-all-databases.sql":
 			// Import database dump via mysql
@@ -1035,45 +1047,63 @@ func safeRestorePath(base, rel string) (string, bool) {
 		return "", false
 	}
 
-	baseAbs, err := filepath.Abs(base)
-	if err != nil {
-		return "", false
-	}
-	baseReal, err := filepath.EvalSymlinks(base)
-	if err != nil {
-		baseReal = baseAbs
-	}
-
+	// The target must not already be a symlink: writing through it would land
+	// wherever it points, not inside the restore root.
 	if info, err := os.Lstat(target); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return "", false
 	}
 
-	existing := target
+	// Compare base and target with every symlink resolved on BOTH sides.
+	// Resolving only one of them rejected any restore root reached through a
+	// symlink — a web root on a second volume, or simply a destination
+	// directory that does not exist yet, where EvalSymlinks(base) failed and
+	// left the base unresolved while the target's existing ancestor came back
+	// resolved. RestoreBackup answers a rejected path with `continue`, so
+	// those entries were dropped and the restore still reported success.
+	baseReal, err := resolveExistingPrefix(base)
+	if err != nil {
+		return "", false
+	}
+	targetReal, err := resolveExistingPrefix(target)
+	if err != nil {
+		return "", false
+	}
+	if !IsInsideDir(targetReal, baseReal) {
+		return "", false
+	}
+
+	return target, true
+}
+
+// resolveExistingPrefix resolves the symlinks in the part of path that exists
+// and appends the components that do not exist yet unchanged, so a directory
+// the restore has not created can still be compared against its eventual
+// location. It is the containment check's notion of "where this really is".
+func resolveExistingPrefix(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	existing := abs
+	var missing []string
 	for {
 		if _, err := os.Lstat(existing); err == nil {
 			break
 		}
 		parent := filepath.Dir(existing)
 		if parent == existing {
-			return "", false
+			return "", fmt.Errorf("no existing ancestor for %s", path)
 		}
+		missing = append([]string{filepath.Base(existing)}, missing...)
 		existing = parent
 	}
 
-	existingReal, err := filepath.EvalSymlinks(existing)
+	real, err := filepath.EvalSymlinks(existing)
 	if err != nil {
-		return "", false
+		return "", err
 	}
-
-	if IsInsideDir(existing, baseAbs) {
-		if !IsInsideDir(existingReal, baseReal) {
-			return "", false
-		}
-	} else if !IsInsideDir(baseAbs, existingReal) {
-		return "", false
-	}
-
-	return target, true
+	return filepath.Join(append([]string{real}, missing...)...), nil
 }
 
 // ScheduleDetail returns the current backup schedule details for the admin UI.

--- a/internal/backup/backup_symlink_restore_test.go
+++ b/internal/backup/backup_symlink_restore_test.go
@@ -1,0 +1,144 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// safeRestorePath compared a resolved path against an unresolved one whenever
+// the destination directory did not exist yet. Any restore root reached
+// through a symlink — /var/www on a second volume, a temp dir on macOS where
+// /var itself is a symlink — failed the containment check, and RestoreBackup
+// answered a rejected path with `continue`. The archive entry was dropped and
+// the restore still reported success.
+//
+// These tests build the symlink explicitly so they fail on every platform,
+// not only where the OS happens to supply one.
+
+// symlinkedRoot returns (linkPath, realPath) where linkPath is a symlink to a
+// real directory, mirroring a restore root that lives behind a link.
+func symlinkedRoot(t *testing.T) (string, string) {
+	t.Helper()
+
+	real := filepath.Join(t.TempDir(), "gercek")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "baglanti")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("sembolik bağlantı kurulamıyor: %v", err)
+	}
+	return link, real
+}
+
+// The destination directory does not exist yet — the case restore always hits
+// on a fresh machine, and the one that silently dropped every entry.
+func TestSafeRestorePathUnderSymlinkedRootMissingDir(t *testing.T) {
+	link, _ := symlinkedRoot(t)
+	base := filepath.Join(link, "domains.d") // yok
+
+	got, ok := safeRestorePath(base, "test.yaml")
+	if !ok {
+		t.Fatal("sembolik bağlantı altındaki hedef reddedildi — restore girdiyi sessizce atlar")
+	}
+	if want := filepath.Join(base, "test.yaml"); got != want {
+		t.Errorf("safeRestorePath = %q, want %q", got, want)
+	}
+}
+
+func TestSafeRestorePathUnderSymlinkedRootExistingDir(t *testing.T) {
+	link, real := symlinkedRoot(t)
+	base := filepath.Join(link, "certs")
+	if err := os.MkdirAll(filepath.Join(real, "certs"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if _, ok := safeRestorePath(base, "sub/x.pem"); !ok {
+		t.Error("var olan dizin sembolik bağlantı altındayken reddedildi")
+	}
+}
+
+// The guard must still reject what it was written to reject.
+func TestSafeRestorePathStillRejectsEscapes(t *testing.T) {
+	link, real := symlinkedRoot(t)
+	base := filepath.Join(link, "kok")
+	if err := os.MkdirAll(filepath.Join(real, "kok"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Traversal out of the base.
+	for _, rel := range []string{"../disari.txt", "../../disari.txt", "a/../../disari.txt"} {
+		if _, ok := safeRestorePath(base, rel); ok {
+			t.Errorf("%q kabul edildi — kök dışına yazılırdı", rel)
+		}
+	}
+
+	// Absolute paths and empty input.
+	for _, rel := range []string{"/etc/passwd", "", "."} {
+		if _, ok := safeRestorePath(base, rel); ok {
+			t.Errorf("%q kabul edildi", rel)
+		}
+	}
+
+	// A symlink already inside the base that points outside it: writing
+	// through it would land outside the restore root.
+	kacis := filepath.Join(t.TempDir(), "hedef")
+	if err := os.MkdirAll(kacis, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(kacis, filepath.Join(real, "kok", "kacis")); err != nil {
+		t.Skipf("sembolik bağlantı kurulamıyor: %v", err)
+	}
+	if _, ok := safeRestorePath(base, "kacis/dosya.txt"); ok {
+		t.Error("kök dışına çıkan sembolik bağlantı üzerinden yazma kabul edildi")
+	}
+	if _, ok := safeRestorePath(base, "kacis"); ok {
+		t.Error("sembolik bağlantının kendisi hedef olarak kabul edildi")
+	}
+}
+
+// End to end: a restore into a symlinked root must actually write the files.
+func TestRestoreBackupIntoSymlinkedRoot(t *testing.T) {
+	m, _ := testManager(t)
+
+	src := t.TempDir()
+	cfg := filepath.Join(src, "uwas.yaml")
+	if err := os.WriteFile(cfg, []byte("config"), 0o644); err != nil {
+		t.Fatalf("yaz: %v", err)
+	}
+	srcDomains := filepath.Join(src, "domains.d")
+	if err := os.MkdirAll(srcDomains, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDomains, "test.yaml"), []byte("host: test.com\n"), 0o644); err != nil {
+		t.Fatalf("yaz: %v", err)
+	}
+
+	m.SetPaths(cfg, "")
+	m.SetDomainPaths("", srcDomains, nil)
+
+	info, err := m.CreateBackup("mem")
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+
+	link, _ := symlinkedRoot(t)
+	dstDomains := filepath.Join(link, "domains.d")
+	m.SetPaths(filepath.Join(link, "uwas.yaml"), "")
+	m.mu.Lock()
+	m.domainsDir = dstDomains
+	m.mu.Unlock()
+
+	if err := m.RestoreBackup(info.Name, "mem"); err != nil {
+		t.Fatalf("RestoreBackup: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dstDomains, "test.yaml"))
+	if err != nil {
+		t.Fatalf("geri yüklenen dosya okunamadı — restore başarı bildirdi ama yazmadı: %v", err)
+	}
+	if string(got) != "host: test.com\n" {
+		t.Errorf("içerik = %q", string(got))
+	}
+}


### PR DESCRIPTION
`safeRestorePath` çözümlenmiş bir yolu çözümlenmemiş biriyle karşılaştırıyordu. Sembolik bağlantı üzerinden erişilen her restore kökü kapsama kontrolünü geçemiyor, `RestoreBackup` ise reddedilen yola `continue` ile cevap veriyordu: **arşiv girdileri düşüyor, restore yine de "başarılı" diyordu.** Operatöre yedeğin geri yüklendiği söyleniyor, dosyalar orada değil.

### Uyuşmazlık

Hedef dizin henüz yokken — yani temiz bir makinedeki normal durumda:

```
base         = /var/.../002/domains.d       (henüz yaratılmadı)
EvalSymlinks(base) hata verir → baseReal ÇÖZÜMLENMEMİŞ mutlak yola düşer
var olan en yakın ata = /var/.../002
existingReal = /private/var/.../002         (ÇÖZÜMLENMİŞ)
/var/...  ⊄  /private/var/...            →  reddedildi
```

Var olan dizinlerde de tetikleniyor: ikinci bir birim üzerindeki bir site kökü, bağlantı üzerinden erişilen bir `certs` dizini ya da `domains.d` yeterli.

### Düzeltme

İki taraf da `resolveExistingPrefix` ile çözümleniyor — yolun var olan kısmındaki bağlantıları çözüp henüz var olmayan bileşenleri olduğu gibi ekliyor. Kapsama kararı tek bir tutarlı ad uzayında veriliyor.

**Koruma gevşetilmedi.** Reddetmesi gerekenleri hâlâ reddediyor: kök dışına çıkma, mutlak yollar, hedefin kendisinin sembolik bağlantı olması, ve kökün içindeki ama dışarıyı gösteren bir bağlantı üzerinden yazma. Mevcut kaçış testleri (`TestSafeRestorePathParentSymlinkChain`, `TestSafeRestorePath_ExistingSymlinkTarget`, `TestSafeRestorePath_BrokenExistingAncestorSymlink`) geçmeye devam ediyor; yenileri bunları bir de sembolik bağlantılı kök karşısında doğruluyor ki düzeltme "kontrolü gevşetme" ile karıştırılmasın.

Reddedilen girdi artık sessizce düşmüyor, loglanıyor.

### Testler

Testler sembolik bağlantıyı kendileri kuruyor — platformun sağlamasına güvenmiyorlar — dolayısıyla Linux'ta da düşüyorlar.

Keskinlik ölçüldü. Eski `safeRestorePath` ile yeni testler:

```
--- FAIL: TestSafeRestorePathUnderSymlinkedRootMissingDir
    sembolik bağlantı altındaki hedef reddedildi — restore girdiyi sessizce atlar
--- FAIL: TestRestoreBackupIntoSymlinkedRoot
    geri yüklenen dosya okunamadı — restore başarı bildirdi ama yazmadı
```

Aynı geri alma, macOS'ta bu pakette **önceden var olan sekiz hatayı** da geri getiriyor (`/var` → `/private/var` bağlantısı yüzünden her "yeni dizine restore" testi bu hataya çarpıyordu):

```
--- FAIL: TestRestoreBackupWithDomainsDir / WithSites / DomainsDirEntry / SitesDirEntry / CertsDirEntry
--- FAIL: TestSafeRestorePathBaseNotYetCreated
--- FAIL: TestRestoreBackupMaxTotalSize   expected max total size error, got <nil>
--- FAIL: TestRestoreBackupMaxFileSize    expected per-file max size error, got <nil>
```

Son ikisi atlamanın toplam olduğunu gösteriyor: hiçbir girdi boyut sınırı kontrolüne bile ulaşmıyordu.

`go test ./internal/backup/` artık tamamen geçiyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
