### PR TITLE
test: takımı macOS'ta koşar hale getir, gizlenen hataları ortaya çıkar

### DIFF
--- a/internal/admin/admin_coverage10_test.go
+++ b/internal/admin/admin_coverage10_test.go
@@ -35,7 +35,7 @@ func TestValidateAppEnvMap_ReservedVars(t *testing.T) {
 		env := map[string]string{name: "value"}
 		err := validateAppEnvMap(env)
 		if err == nil {
-			t.Errorf("expected error for reserved env var %q", name)
+			t.Fatalf("expected error for reserved env var %q", name)
 		}
 		if !strings.Contains(err.Error(), "reserved") {
 			t.Errorf("error for %q should mention 'reserved', got: %v", name, err)

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -271,7 +271,7 @@ func TestAuthenticateDisabledUser(t *testing.T) {
 
 	_, err := m.Authenticate("alice", "secret")
 	if err == nil {
-		t.Error("expected error for disabled user")
+		t.Fatal("expected error for disabled user")
 	}
 	if err.Error() != "user disabled" {
 		t.Errorf("expected 'user disabled' error, got %q", err.Error())
@@ -344,7 +344,7 @@ func TestValidateSessionExpired(t *testing.T) {
 
 	_, err := m.ValidateSession(session.Token)
 	if err == nil {
-		t.Error("expected error for expired session")
+		t.Fatal("expected error for expired session")
 	}
 	if err.Error() != "session expired" {
 		t.Errorf("expected 'session expired' error, got %q", err.Error())
@@ -708,7 +708,7 @@ func TestDeleteUserNotFound(t *testing.T) {
 
 	err := m.DeleteUser("nonexistent")
 	if err == nil {
-		t.Error("expected error for deleting nonexistent user")
+		t.Fatal("expected error for deleting nonexistent user")
 	}
 	if err.Error() != "user not found" {
 		t.Errorf("expected 'user not found' error, got %q", err.Error())
@@ -826,7 +826,7 @@ func TestUpdateUserNotFound(t *testing.T) {
 
 	err := m.UpdateUser("nonexistent", &User{Email: "test@test.com"})
 	if err == nil {
-		t.Error("expected error for nonexistent user")
+		t.Fatal("expected error for nonexistent user")
 	}
 	if err.Error() != "user not found" {
 		t.Errorf("expected 'user not found' error, got %q", err.Error())
@@ -937,7 +937,7 @@ func TestRegenerateAPIKeyNotFound(t *testing.T) {
 
 	_, err := m.RegenerateAPIKey("nonexistent")
 	if err == nil {
-		t.Error("expected error for nonexistent user")
+		t.Fatal("expected error for nonexistent user")
 	}
 	if err.Error() != "user not found" {
 		t.Errorf("expected 'user not found' error, got %q", err.Error())
@@ -991,7 +991,7 @@ func TestChangePasswordWrongCurrent(t *testing.T) {
 
 	err := m.ChangePassword("alice", "wrongcurrent", "newpass")
 	if err == nil {
-		t.Error("expected error for wrong current password")
+		t.Fatal("expected error for wrong current password")
 	}
 	if err.Error() != "invalid current password" {
 		t.Errorf("expected 'invalid current password' error, got %q", err.Error())
@@ -1009,7 +1009,7 @@ func TestChangePasswordNotFound(t *testing.T) {
 
 	err := m.ChangePassword("nonexistent", "old", "new")
 	if err == nil {
-		t.Error("expected error for nonexistent user")
+		t.Fatal("expected error for nonexistent user")
 	}
 	if err.Error() != "user not found" {
 		t.Errorf("expected 'user not found' error, got %q", err.Error())
@@ -1864,7 +1864,7 @@ func TestCreateUserPasswordTooLong(t *testing.T) {
 
 	_, err := m.CreateUser("alice", "", longPass, RoleAdmin, nil)
 	if err == nil {
-		t.Error("expected error for password exceeding 72 bytes")
+		t.Fatal("expected error for password exceeding 72 bytes")
 	}
 	if !strings.Contains(err.Error(), "hash password") {
 		t.Errorf("expected hash password error, got %q", err.Error())
@@ -1878,7 +1878,7 @@ func TestUpdateUserPasswordTooLong(t *testing.T) {
 
 	err := m.UpdateUser("alice", &User{Password: longPass, Enabled: true})
 	if err == nil {
-		t.Error("expected error for password exceeding 72 bytes in update")
+		t.Fatal("expected error for password exceeding 72 bytes in update")
 	}
 	if !strings.Contains(err.Error(), "hash password") {
 		t.Errorf("expected hash password error, got %q", err.Error())
@@ -1892,7 +1892,7 @@ func TestChangePasswordNewTooLong(t *testing.T) {
 
 	err := m.ChangePassword("alice", "secret", longPass)
 	if err == nil {
-		t.Error("expected error for new password exceeding 72 bytes")
+		t.Fatal("expected error for new password exceeding 72 bytes")
 	}
 	if !strings.Contains(err.Error(), "hash password") {
 		t.Errorf("expected hash password error, got %q", err.Error())

--- a/internal/cache/coverage3_test.go
+++ b/internal/cache/coverage3_test.go
@@ -381,7 +381,7 @@ func TestRedisRespCommandLockedNilConn(t *testing.T) {
 	_, err := c.commandLocked("PING")
 	c.mu.Unlock()
 	if err == nil {
-		t.Error("expected error for nil connection")
+		t.Fatal("expected error for nil connection")
 	}
 	if err.Error() != "redis: not connected" {
 		t.Errorf("unexpected error: %v", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -197,7 +197,7 @@ func TestHelpCommandRunWithUnknownCommand(t *testing.T) {
 
 	err := helpCmd.Run([]string{"nonexistent"})
 	if err == nil {
-		t.Error("expected error for unknown command")
+		t.Fatal("expected error for unknown command")
 	}
 	if !strings.Contains(err.Error(), "unknown command") {
 		t.Errorf("error = %q, should mention unknown command", err.Error())

--- a/internal/deploy/deploy_extra_test.go
+++ b/internal/deploy/deploy_extra_test.go
@@ -148,7 +148,7 @@ func TestWaitForAppImpl_Timeout(t *testing.T) {
 	start := time.Now()
 	err = waitForAppImpl(addr, 300*time.Millisecond)
 	if err == nil {
-		t.Error("waitForAppImpl() expected timeout error")
+		t.Fatal("waitForAppImpl() expected timeout error")
 	}
 	if err != nil && !strings.Contains(err.Error(), "not responding") {
 		t.Errorf("error = %v, want 'not responding'", err)

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -409,7 +409,7 @@ func TestRunShellFailure(t *testing.T) {
 func TestRunShellNullByte(t *testing.T) {
 	_, err := runShell("", nil, "echo hello\x00world")
 	if err == nil {
-		t.Error("expected error for command with null byte")
+		t.Fatal("expected error for command with null byte")
 	}
 	if !strings.Contains(err.Error(), "null byte") {
 		t.Errorf("expected null byte error, got: %v", err)
@@ -606,7 +606,7 @@ func TestDeployGit_CloneFails(t *testing.T) {
 	err := m.deployGit(req, appRoot, "main", nil, status, &log)
 
 	if err == nil {
-		t.Error("deployGit() expected error for failed clone")
+		t.Fatal("deployGit() expected error for failed clone")
 	}
 	if !strings.Contains(err.Error(), "git clone") {
 		t.Errorf("error = %v, expected 'git clone' in error", err)
@@ -635,7 +635,7 @@ func TestDeployGit_NoGitURL(t *testing.T) {
 	err := m.deployGit(req, appRoot, "main", nil, status, &log)
 
 	if err == nil {
-		t.Error("deployGit() expected error for empty GitURL")
+		t.Fatal("deployGit() expected error for empty GitURL")
 	}
 	if !strings.Contains(err.Error(), "no git URL") {
 		t.Errorf("error = %v, expected 'no git URL' in error", err)
@@ -775,7 +775,7 @@ func TestDeployGit_BuildFails(t *testing.T) {
 	err := m.deployGit(req, appRoot, "main", nil, status, &log)
 
 	if err == nil {
-		t.Error("deployGit() expected error for failed build")
+		t.Fatal("deployGit() expected error for failed build")
 	}
 	if !strings.Contains(err.Error(), "build failed") {
 		t.Errorf("error = %v, expected 'build failed' in error", err)
@@ -877,7 +877,7 @@ func TestDeployDocker_BuildFails(t *testing.T) {
 	err := m.deployDocker(req, appRoot, status, &log)
 
 	if err == nil {
-		t.Error("deployDocker() expected error for failed build")
+		t.Fatal("deployDocker() expected error for failed build")
 	}
 	if !strings.Contains(err.Error(), "docker build") {
 		t.Errorf("error = %v, expected 'docker build' in error", err)
@@ -921,7 +921,7 @@ func TestDeployDocker_RunFails(t *testing.T) {
 	err := m.deployDocker(req, appRoot, status, &log)
 
 	if err == nil {
-		t.Error("deployDocker() expected error for failed run")
+		t.Fatal("deployDocker() expected error for failed run")
 	}
 	if !strings.Contains(err.Error(), "docker run") {
 		t.Errorf("error = %v, expected 'docker run' in error", err)
@@ -958,7 +958,7 @@ func TestDeployDocker_InvalidDockerfilePath(t *testing.T) {
 	err := m.deployDocker(req, t.TempDir(), status, &log)
 
 	if err == nil {
-		t.Error("deployDocker() expected error for absolute Dockerfile path")
+		t.Fatal("deployDocker() expected error for absolute Dockerfile path")
 	}
 	if !strings.Contains(err.Error(), "must be relative") {
 		t.Errorf("error = %v, expected 'must be relative' in error", err)
@@ -971,7 +971,7 @@ func TestDeployDocker_InvalidDockerfilePath(t *testing.T) {
 	err = m.deployDocker(req, t.TempDir(), status, &log)
 
 	if err == nil {
-		t.Error("deployDocker() expected error for traversal Dockerfile path")
+		t.Fatal("deployDocker() expected error for traversal Dockerfile path")
 	}
 	if !strings.Contains(err.Error(), "must be relative") {
 		t.Errorf("error = %v, expected 'must be relative' in error", err)
@@ -1136,7 +1136,7 @@ func TestDeployGit_FetchFails(t *testing.T) {
 	err := m.deployGit(req, appRoot, "main", nil, status, &log)
 
 	if err == nil {
-		t.Error("deployGit() expected error for failed fetch")
+		t.Fatal("deployGit() expected error for failed fetch")
 	}
 	if !strings.Contains(err.Error(), "git fetch") {
 		t.Errorf("error = %v, expected 'git fetch' in error", err)
@@ -1178,7 +1178,7 @@ func TestDeployGit_ResetFails(t *testing.T) {
 	err := m.deployGit(req, appRoot, "nonexistent", nil, status, &log)
 
 	if err == nil {
-		t.Error("deployGit() expected error for failed reset")
+		t.Fatal("deployGit() expected error for failed reset")
 	}
 	if !strings.Contains(err.Error(), "git reset") {
 		t.Errorf("error = %v, expected 'git reset' in error", err)

--- a/internal/filemanager/filemanager_test.go
+++ b/internal/filemanager/filemanager_test.go
@@ -171,7 +171,7 @@ func TestListNonexistentDir(t *testing.T) {
 	dir := t.TempDir()
 	_, err := List(dir, "nonexistent")
 	if err == nil {
-		t.Error("expected error listing nonexistent directory")
+		t.Fatal("expected error listing nonexistent directory")
 	}
 }
 

--- a/internal/firewall/manager_test.go
+++ b/internal/firewall/manager_test.go
@@ -374,7 +374,7 @@ func TestAllowPort_NoUFW(t *testing.T) {
 
 	err := AllowPort("80", "tcp")
 	if err == nil {
-		t.Error("AllowPort() expected error for missing ufw, got nil")
+		t.Fatal("AllowPort() expected error for missing ufw, got nil")
 	}
 	if err.Error() != "ufw not installed" {
 		t.Errorf("error = %q, want %q", err.Error(), "ufw not installed")
@@ -478,7 +478,7 @@ func TestDenyPort_NoUFW(t *testing.T) {
 
 	err := DenyPort("3306", "tcp")
 	if err == nil {
-		t.Error("DenyPort() expected error for missing ufw, got nil")
+		t.Fatal("DenyPort() expected error for missing ufw, got nil")
 	}
 	if err.Error() != "ufw not installed" {
 		t.Errorf("error = %q, want %q", err.Error(), "ufw not installed")
@@ -520,7 +520,7 @@ func TestDeleteRule_NoUFW(t *testing.T) {
 
 	err := DeleteRule(1)
 	if err == nil {
-		t.Error("DeleteRule() expected error for missing ufw, got nil")
+		t.Fatal("DeleteRule() expected error for missing ufw, got nil")
 	}
 	if err.Error() != "ufw not installed" {
 		t.Errorf("error = %q, want %q", err.Error(), "ufw not installed")
@@ -720,7 +720,7 @@ func TestDenyPortProtectedAdminPort(t *testing.T) {
 func TestParsePortSpecInvertedRange(t *testing.T) {
 	_, _, err := parsePortSpec("80:20")
 	if err == nil {
-		t.Error("expected error for inverted port range")
+		t.Fatal("expected error for inverted port range")
 	}
 	if !strings.Contains(err.Error(), "invalid port range") {
 		t.Errorf("unexpected error: %v", err)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -287,7 +287,7 @@ func TestCallToolDomainGetNotFound(t *testing.T) {
 
 	_, err := s.CallTool("domain_get", json.RawMessage(`{"host":"nonexistent.com"}`))
 	if err == nil {
-		t.Error("expected error for non-existent domain")
+		t.Fatal("expected error for non-existent domain")
 	}
 	if !strings.Contains(err.Error(), "domain not found") {
 		t.Errorf("unexpected error: %v", err)

--- a/internal/phpmanager/coverage_test.go
+++ b/internal/phpmanager/coverage_test.go
@@ -25,7 +25,7 @@ func TestStartFPMInvalidBinary(t *testing.T) {
 
 	err := m.StartFPM("8.4.19", "127.0.0.1:9000")
 	if err == nil {
-		t.Error("expected error when starting FPM with invalid binary path")
+		t.Fatal("expected error when starting FPM with invalid binary path")
 	}
 	if !strings.Contains(err.Error(), "start php-cgi") {
 		t.Errorf("unexpected error: %v", err)
@@ -42,7 +42,7 @@ func TestStopFPMForNonRunningVersion(t *testing.T) {
 
 	err := m.StopFPM("8.4.19")
 	if err == nil {
-		t.Error("expected error when stopping FPM that is not running")
+		t.Fatal("expected error when stopping FPM that is not running")
 	}
 	if !strings.Contains(err.Error(), "not running") {
 		t.Errorf("unexpected error: %v", err)
@@ -66,7 +66,7 @@ func TestAssignDomainAlreadyAssignedDifferentVersion(t *testing.T) {
 	// Try to assign same domain with different version - should still fail.
 	_, err = m.AssignDomain("blog.com", "8.3")
 	if err == nil {
-		t.Error("expected error for already-assigned domain")
+		t.Fatal("expected error for already-assigned domain")
 	}
 	if !strings.Contains(err.Error(), "already has") {
 		t.Errorf("unexpected error: %v", err)
@@ -400,7 +400,7 @@ func TestStopDomainNotAssigned(t *testing.T) {
 
 	err := m.StopDomain("noexist.com")
 	if err == nil {
-		t.Error("expected error for stopping unassigned domain")
+		t.Fatal("expected error for stopping unassigned domain")
 	}
 	if !strings.Contains(err.Error(), "no PHP assignment") {
 		t.Errorf("unexpected error: %v", err)
@@ -422,7 +422,7 @@ func TestStopDomainNotRunningCov(t *testing.T) {
 
 	err = m.StopDomain("stop-notrunning.com")
 	if err == nil {
-		t.Error("expected error for stopping domain that is not running")
+		t.Fatal("expected error for stopping domain that is not running")
 	}
 	if !strings.Contains(err.Error(), "not running") {
 		t.Errorf("unexpected error: %v", err)
@@ -439,7 +439,7 @@ func TestStopDomainRunning(t *testing.T) {
 
 	// Use a long-running mock process (sleep)
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	_, err := m.AssignDomain("stop-running.com", "8.4")
@@ -470,7 +470,7 @@ func TestStartDomainAlreadyRunningCov(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	_, err := m.AssignDomain("already-running.com", "8.4")
@@ -487,7 +487,8 @@ func TestStartDomainAlreadyRunningCov(t *testing.T) {
 	// Try starting again - should fail
 	err = m.StartDomain("already-running.com")
 	if err == nil {
-		t.Error("expected error for already running domain")
+		// Fatal, not Error: the next line dereferences err.
+		t.Fatal("expected error for already running domain")
 	}
 	if !strings.Contains(err.Error(), "already running") {
 		t.Errorf("unexpected error: %v", err)
@@ -504,7 +505,7 @@ func TestStartDomainNotAssigned(t *testing.T) {
 
 	err := m.StartDomain("notassigned.com")
 	if err == nil {
-		t.Error("expected error for starting unassigned domain")
+		t.Fatal("expected error for starting unassigned domain")
 	}
 	if !strings.Contains(err.Error(), "no PHP assignment") {
 		t.Errorf("unexpected error: %v", err)
@@ -530,7 +531,7 @@ func TestStartDomainExecFailure(t *testing.T) {
 
 	err = m.StartDomain("exec-fail.com")
 	if err == nil {
-		t.Error("expected error when exec fails")
+		t.Fatal("expected error when exec fails")
 	}
 	if !strings.Contains(err.Error(), "start php-cgi") {
 		t.Errorf("unexpected error: %v", err)
@@ -546,7 +547,7 @@ func TestStartDomainWithChangeCallback(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	var callbackDomain, callbackAddr string
@@ -586,7 +587,7 @@ func TestUnassignDomainWithRunningProcess(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	_, err := m.AssignDomain("unassign-running.com", "8.4")
@@ -627,7 +628,7 @@ func TestStopFPMRunningProcess(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	err := m.StartFPM("8.4.19", "127.0.0.1:9000")
@@ -668,7 +669,7 @@ func TestStartFPMAlreadyRunningCov(t *testing.T) {
 	// Try again - should fail
 	err = m.StartFPM("8.4.19", "127.0.0.1:9001")
 	if err == nil {
-		t.Error("expected error for already running version")
+		t.Fatal("expected error for already running version")
 	}
 	if !strings.Contains(err.Error(), "already running") {
 		t.Errorf("unexpected error: %v", err)
@@ -682,7 +683,7 @@ func TestStartFPMVersionNotFound(t *testing.T) {
 
 	err := m.StartFPM("9.9.9", "127.0.0.1:9000")
 	if err == nil {
-		t.Error("expected error for unknown version")
+		t.Fatal("expected error for unknown version")
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("unexpected error: %v", err)
@@ -699,7 +700,7 @@ func TestStatusWithRunningProcess(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	err := m.StartFPM("8.4.19", "127.0.0.1:9000")
@@ -768,7 +769,7 @@ func TestStopAllWithProcesses(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	// Start a global FPM process
@@ -939,7 +940,7 @@ func TestProbeVersionParseFailure(t *testing.T) {
 
 	_, err := m.probe("/fake/php")
 	if err == nil {
-		t.Error("expected error when version cannot be parsed")
+		t.Fatal("expected error when version cannot be parsed")
 	}
 	if !strings.Contains(err.Error(), "could not parse version") {
 		t.Errorf("unexpected error: %v", err)
@@ -956,7 +957,7 @@ func TestProbeExecFailure(t *testing.T) {
 
 	_, err := m.probe("/fake/php")
 	if err == nil {
-		t.Error("expected error when exec fails")
+		t.Fatal("expected error when exec fails")
 	}
 	if !strings.Contains(err.Error(), "version check") {
 		t.Errorf("unexpected error: %v", err)
@@ -1033,7 +1034,7 @@ func TestAutoStartAllWithError(t *testing.T) {
 
 	err = m.AutoStartAll()
 	if err == nil {
-		t.Error("expected error from AutoStartAll when StartDomain fails")
+		t.Fatal("expected error from AutoStartAll when StartDomain fails")
 	}
 	if !strings.Contains(err.Error(), "auto-start errors") {
 		t.Errorf("unexpected error: %v", err)
@@ -1049,7 +1050,7 @@ func TestAutoStartAllSuccess(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	_, err := m.AssignDomain("autostart-ok.com", "8.4")
@@ -1076,7 +1077,7 @@ func TestGetDomainInstancesWithRunning(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	_, err := m.AssignDomain("running-inst.com", "8.4")

--- a/internal/phpmanager/domain_test.go
+++ b/internal/phpmanager/domain_test.go
@@ -72,7 +72,7 @@ func TestAssignDomainDuplicate(t *testing.T) {
 
 	_, err = m.AssignDomain("blog.com", "8.4")
 	if err == nil {
-		t.Error("expected error for duplicate domain assignment")
+		t.Fatal("expected error for duplicate domain assignment")
 	}
 	if !strings.Contains(err.Error(), "already has") {
 		t.Errorf("unexpected error: %v", err)
@@ -84,7 +84,7 @@ func TestAssignDomainNotFound(t *testing.T) {
 
 	_, err := m.AssignDomain("blog.com", "9.9")
 	if err == nil {
-		t.Error("expected error for non-existent version")
+		t.Fatal("expected error for non-existent version")
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("unexpected error: %v", err)
@@ -463,7 +463,7 @@ func TestAutoStartAllErrors(t *testing.T) {
 
 	err := m.AutoStartAll()
 	if err == nil {
-		t.Error("expected error from AutoStartAll with failing binary")
+		t.Fatal("expected error from AutoStartAll with failing binary")
 	}
 	if !strings.Contains(err.Error(), "auto-start errors") {
 		t.Errorf("unexpected error: %v", err)

--- a/internal/phpmanager/extra_coverage_test.go
+++ b/internal/phpmanager/extra_coverage_test.go
@@ -17,7 +17,7 @@ import (
 // blocks ~100s on this platform and is killed by the test, never run to
 // completion, so it is a safe stand-in for a live PHP daemon.
 func longRunningCmd() *exec.Cmd {
-	return exec.Command("ping", "-n", "100", "127.0.0.1")
+	return exec.Command("sleep", "100")
 }
 
 // --- manager.go: RegisterExistingDomain ---

--- a/internal/phpmanager/full_coverage_test.go
+++ b/internal/phpmanager/full_coverage_test.go
@@ -411,7 +411,7 @@ func TestRunInstallFailure(t *testing.T) {
 
 	_, err := RunInstall("8.3")
 	if err == nil {
-		t.Error("expected error from failing install command")
+		t.Fatal("expected error from failing install command")
 	}
 	if !strings.Contains(err.Error(), "command failed") {
 		t.Errorf("unexpected error: %v", err)
@@ -503,7 +503,7 @@ func TestSetDomainConfigBlockedDirective(t *testing.T) {
 
 	err := m.SetDomainConfig("blog.com", "disable_functions", "exec")
 	if err == nil {
-		t.Error("expected error for blocked directive")
+		t.Fatal("expected error for blocked directive")
 	}
 	if !strings.Contains(err.Error(), "blocked for security") {
 		t.Errorf("unexpected error: %v", err)
@@ -717,7 +717,7 @@ func TestDisableVersionWithAttachedDomains(t *testing.T) {
 
 	err := m.DisableVersion("8.4")
 	if err == nil {
-		t.Error("expected error when domain is attached")
+		t.Fatal("expected error when domain is attached")
 	}
 	if !strings.Contains(err.Error(), "cannot disable") {
 		t.Errorf("unexpected error: %v", err)
@@ -752,7 +752,7 @@ func TestStartFPMDaemonSuccess(t *testing.T) {
 
 	// Mock exec command to use a long-running process
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	err := m.startFPMDaemon("8.4.19", "/usr/sbin/php-fpm8.4", "127.0.0.1:9000")
@@ -795,7 +795,7 @@ func TestStartFPMDaemonPoolUser(t *testing.T) {
 
 	m := New(testLogger())
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 	killFPM := func(version string) {
 		if val, ok := m.processes.Load(version); ok {
@@ -837,7 +837,7 @@ func TestStartFPMDaemonExecFailure(t *testing.T) {
 
 	err := m.startFPMDaemon("8.4.19", "/nonexistent/php-fpm", "127.0.0.1:9000")
 	if err == nil {
-		t.Error("expected error when exec fails")
+		t.Fatal("expected error when exec fails")
 	}
 	if !strings.Contains(err.Error(), "start php-fpm") {
 		t.Errorf("unexpected error: %v", err)
@@ -855,7 +855,7 @@ func TestStartFPMWithFPMSAPI(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	err := m.StartFPM("8.4.19", "127.0.0.1:9000")
@@ -875,7 +875,7 @@ func TestStartFPMWrongSAPI(t *testing.T) {
 
 	err := m.StartFPM("8.4.19", "127.0.0.1:9000")
 	if err == nil {
-		t.Error("expected error for CLI SAPI")
+		t.Fatal("expected error for CLI SAPI")
 	}
 	if !strings.Contains(err.Error(), "not cgi-fcgi") {
 		t.Errorf("unexpected error: %v", err)
@@ -962,7 +962,7 @@ func TestStartDomainWrongSAPI(t *testing.T) {
 
 	err := m.StartDomain("sapi-test.com")
 	if err == nil {
-		t.Error("expected error for CLI SAPI")
+		t.Fatal("expected error for CLI SAPI")
 	}
 	if !strings.Contains(err.Error(), "not cgi-fcgi") {
 		t.Errorf("unexpected error: %v", err)
@@ -1509,7 +1509,7 @@ func TestStopDomainCleansUpTmpINI(t *testing.T) {
 	os.WriteFile(tmpFile, []byte("test"), 0644)
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	m.AssignDomain("stop-cleanup.com", "8.4")
@@ -1743,12 +1743,12 @@ func TestAutoRestartOnCrash(t *testing.T) {
 		callCount++
 		if callCount == 1 {
 			// First call: process that exits with error (simulates crash).
-			// Use a command guaranteed to fail with non-zero exit.
-			cmd := exec.Command("ping", "-n", "1", "0.0.0.0.0.0.invalid.host.test")
+			// false(1) exits non-zero on every POSIX platform.
+			cmd := exec.Command("false")
 			return cmd
 		}
 		// Subsequent calls: long-running process (auto-restart succeeds)
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	m.AssignDomain("crash.com", "8.4")
@@ -1784,7 +1784,7 @@ func TestStopDomainDoesNotAutoRestart(t *testing.T) {
 	var startCount atomic.Int32
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
 		startCount.Add(1)
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	if _, err := m.AssignDomain("manual-stop.com", "8.4"); err != nil {
@@ -2108,7 +2108,7 @@ func TestStartDomainBuildINIError(t *testing.T) {
 	}
 
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	m.AssignDomain("buildini-err.com", "8.4")
@@ -2178,7 +2178,7 @@ func TestStartDomainAutoRestartCleansUpTmpINI(t *testing.T) {
 			return exec.Command("echo", "exit-quick")
 		}
 		// Subsequent: long-running for auto-restart
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	m.AssignDomain("tmpini-goroutine.com", "8.4")
@@ -2490,7 +2490,7 @@ func TestStartDomainAutoRestartNormalExit(t *testing.T) {
 			// Normal exit (exit code 0) — no crash
 			return exec.Command("echo", "normal-exit")
 		}
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	m.AssignDomain("normalexit.com", "8.4")
@@ -2939,7 +2939,7 @@ func TestBuildDomainINICreateTempFailure(t *testing.T) {
 
 	_, err := m.buildDomainINI("test.com", inst, map[string]string{"memory_limit": "256M"})
 	if err == nil {
-		t.Error("expected error when CreateTemp fails")
+		t.Fatal("expected error when CreateTemp fails")
 	}
 	if !strings.Contains(err.Error(), "no space left") {
 		t.Errorf("unexpected error: %v", err)
@@ -3006,7 +3006,7 @@ func TestSetConfigRawCreateConfigFails(t *testing.T) {
 
 	err := m.SetConfigRaw("8.4.19", "content")
 	if err == nil {
-		t.Error("expected error when config creation fails")
+		t.Fatal("expected error when config creation fails")
 	}
 	if !strings.Contains(err.Error(), "cannot create") {
 		t.Errorf("unexpected error: %v", err)
@@ -3045,7 +3045,7 @@ func TestSetConfigCreateConfigFails(t *testing.T) {
 
 	err := m.SetConfig("8.4.19", "memory_limit", "512M")
 	if err == nil {
-		t.Error("expected error when config creation fails")
+		t.Fatal("expected error when config creation fails")
 	}
 	if !strings.Contains(err.Error(), "cannot create") {
 		t.Errorf("unexpected error: %v", err)
@@ -3070,7 +3070,7 @@ func TestStartFPMDaemonWriteConfigFailure(t *testing.T) {
 	m := New(testLogger())
 	err := m.startFPMDaemon("8.4.19", "/usr/bin/php-fpm8.4", "127.0.0.1:9000")
 	if err == nil {
-		t.Error("expected error when write config fails")
+		t.Fatal("expected error when write config fails")
 	}
 	if !strings.Contains(err.Error(), "write fpm config") {
 		t.Errorf("unexpected error: %v", err)
@@ -3080,7 +3080,7 @@ func TestStartFPMDaemonWriteConfigFailure(t *testing.T) {
 func TestStartFPMDaemonBackgroundCleanup(t *testing.T) {
 	m := New(testLogger())
 	m.execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("ping", "-n", "100", "127.0.0.1")
+		return exec.Command("sleep", "100")
 	}
 
 	err := m.startFPMDaemon("8.4.19", "/usr/bin/php-fpm8.4", "127.0.0.1:9000")

--- a/internal/server/coverage_test.go
+++ b/internal/server/coverage_test.go
@@ -1948,7 +1948,7 @@ func TestStartHTTPSBadAddress(t *testing.T) {
 
 	err := s.startHTTPS()
 	if err == nil {
-		t.Error("startHTTPS should fail with invalid address")
+		t.Fatal("startHTTPS should fail with invalid address")
 		if s.httpsSrv != nil {
 			s.httpsSrv.Close()
 		}
@@ -2033,7 +2033,7 @@ func TestReloadNoConfigPathCov(t *testing.T) {
 
 	err := s.reload()
 	if err == nil {
-		t.Error("reload should fail when configPath is empty")
+		t.Fatal("reload should fail when configPath is empty")
 	}
 	if !strings.Contains(err.Error(), "no config path") {
 		t.Errorf("unexpected error: %v", err)
@@ -2056,7 +2056,7 @@ func TestReloadInvalidConfigFile(t *testing.T) {
 
 	err := s.reload()
 	if err == nil {
-		t.Error("reload should fail with invalid config file")
+		t.Fatal("reload should fail with invalid config file")
 	}
 	if !strings.Contains(err.Error(), "reload config") {
 		t.Errorf("unexpected error: %v", err)

--- a/internal/server/server_lifecycle_cov_test.go
+++ b/internal/server/server_lifecycle_cov_test.go
@@ -38,7 +38,7 @@ func TestNewFullFeatured(t *testing.T) {
 			},
 			Users: config.UsersConfig{
 				Enabled:                    true,
-				AllowReseller:               true,
+				AllowReseller:              true,
 				AllowLegacyPlaintextAPIKey: true,
 			},
 			MCP: config.MCPConfig{Enabled: true, Listen: "127.0.0.1:0"},

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -306,7 +306,7 @@ func TestReloadNoConfigPath(t *testing.T) {
 
 	err := s.reload()
 	if err == nil {
-		t.Error("expected error when no config path set")
+		t.Fatal("expected error when no config path set")
 	}
 	if !strings.Contains(err.Error(), "no config path set") {
 		t.Errorf("error = %q, should mention no config path", err.Error())

--- a/internal/terminal/handler_test.go
+++ b/internal/terminal/handler_test.go
@@ -117,7 +117,7 @@ func TestUpgradeWebSocketNotWebsocket(t *testing.T) {
 	h := &Handler{Logger: &logger.Logger{}}
 	_, err := h.UpgradeWebSocket(w, req)
 	if err == nil {
-		t.Error("expected error for non-websocket upgrade")
+		t.Fatal("expected error for non-websocket upgrade")
 	}
 	if !bytes.Contains([]byte(err.Error()), []byte("not a websocket")) {
 		t.Errorf("unexpected error: %v", err)
@@ -134,7 +134,7 @@ func TestUpgradeWebSocketNoHijack(t *testing.T) {
 	h := &Handler{Logger: &logger.Logger{}}
 	_, err := h.UpgradeWebSocket(w, req)
 	if err == nil {
-		t.Error("expected error for non-hijackable response writer")
+		t.Fatal("expected error for non-hijackable response writer")
 	}
 	if !bytes.Contains([]byte(err.Error()), []byte("hijacking")) {
 		t.Errorf("unexpected error: %v", err)
@@ -325,7 +325,7 @@ func TestWSConnReadMessageTooLarge(t *testing.T) {
 
 	_, err := conn.ReadMessage()
 	if err == nil {
-		t.Error("expected error for oversized frame")
+		t.Fatal("expected error for oversized frame")
 	}
 	// Error could be "frame too large", EOF, or "unexpected EOF" depending on timing
 	errStr := err.Error()

--- a/internal/tls/manager_test.go
+++ b/internal/tls/manager_test.go
@@ -791,7 +791,7 @@ func TestGetCertificateOnDemandAskReject(t *testing.T) {
 	hello := &tls.ClientHelloInfo{ServerName: "unknown-domain.com"}
 	_, err := m.GetCertificate(hello)
 	if err == nil {
-		t.Error("should reject when ask URL returns non-200")
+		t.Fatal("should reject when ask URL returns non-200")
 	}
 	if !strings.Contains(err.Error(), "rejected") {
 		t.Errorf("error = %v, want contains 'rejected'", err)
@@ -835,7 +835,7 @@ func TestGetCertificateOnDemandRateLimited(t *testing.T) {
 	hello := &tls.ClientHelloInfo{ServerName: "ratelimited.com"}
 	_, err := m.GetCertificate(hello)
 	if err == nil {
-		t.Error("should error when rate limited")
+		t.Fatal("should error when rate limited")
 	}
 	if !strings.Contains(err.Error(), "rate limit") {
 		t.Errorf("error = %v, want contains 'rate limit'", err)

--- a/internal/wordpress/installer_test.go
+++ b/internal/wordpress/installer_test.go
@@ -1061,7 +1061,7 @@ func TestUpdateCore_DownloadFails(t *testing.T) {
 
 	_, err := UpdateCore(t.TempDir())
 	if err == nil {
-		t.Error("expected error")
+		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), "download failed") {
 		t.Errorf("error = %q", err)
@@ -1374,7 +1374,7 @@ func TestSetDebugMode_FileNotFound(t *testing.T) {
 
 	err := SetDebugMode("/nonexistent/path", true)
 	if err == nil {
-		t.Error("expected error")
+		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), "read wp-config.php") {
 		t.Errorf("error = %q", err)
@@ -1676,7 +1676,7 @@ func TestCreateMySQLDB_NoMySQL(t *testing.T) {
 	var log strings.Builder
 	err := createMySQLDB("testdb", "testuser", "testpass", "localhost", &log)
 	if err == nil {
-		t.Error("expected error")
+		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), "mysql client not found") {
 		t.Errorf("err = %q", err)
@@ -2009,7 +2009,7 @@ func TestDownloadAndExtract_ExtractFails(t *testing.T) {
 	var log strings.Builder
 	err := downloadAndExtract(t.TempDir(), &log)
 	if err == nil {
-		t.Error("expected extract error")
+		t.Fatal("expected extract error")
 	}
 	if !strings.Contains(err.Error(), "extract failed") {
 		t.Errorf("err = %q", err)
@@ -2358,7 +2358,7 @@ func TestUpdateCore_ExtractFails(t *testing.T) {
 
 	_, err := UpdateCore(t.TempDir())
 	if err == nil {
-		t.Error("expected error")
+		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), "extract failed") {
 		t.Errorf("err = %q", err)
@@ -2654,7 +2654,7 @@ func TestUpdateCore_WalkError(t *testing.T) {
 
 	_, err := UpdateCore(webRoot)
 	if err == nil {
-		t.Error("expected error from Walk")
+		t.Fatal("expected error from Walk")
 	}
 	if !strings.Contains(err.Error(), "copy failed") {
 		t.Errorf("err = %q", err)
@@ -2705,7 +2705,7 @@ func TestUpdateCore_WalkReadFileFails(t *testing.T) {
 
 	_, err := UpdateCore(webRoot)
 	if err == nil {
-		t.Error("expected error from readFile failure")
+		t.Fatal("expected error from readFile failure")
 	}
 	if !strings.Contains(err.Error(), "copy failed") {
 		t.Errorf("err = %q", err)


### PR DESCRIPTION
`go test ./...` macOS'ta tamamlanamıyordu; Linux CI ise yeşildi. Üç ayrı sorun — üçü de hata *üretmiyor*, gerçek hataları *gizliyordu*.

### Taşınabilir olmayan süreç taklitleri (21 yer)

phpmanager testleri uzun süren bir süreci `ping -n 100 127.0.0.1` ile taklit ediyordu — Windows `ping` sözdizimi. Linux `ping` iki işleneni kabul edip süresiz koşuyor, yani taklit orada tesadüfen çalışıyordu. macOS `ping` reddedip 64 ile anında çıkıyor:

```
usage: ping [-AaDdfnoQqRrv] [-c count] ...   çıkış kodu: 64
```

Sonuç: canlı bir alt sürece bağlı her test, çoktan ölmüş bir süreç üzerinde iddiada bulunuyordu. `StopDomain` "not running" diyordu, `StartDomain`'in already-running koruması hiç tetiklenmiyordu, ve ardından `err.Error()` çağıran test panikleyip **tüm paketi** yanında götürüyordu.

`internal/cloudflare` aynı şeyi doğru yapıyor — `runtime.GOOS == "windows"` koşuluyla, diğer her platformda `sleep`. phpmanager sadece Windows dalını koruma olmadan kopyalamış. Artık `sleep 100` kullanıyorlar; başarısız olması gereken taklit ise geçersiz bir hosta `ping` yerine `false`.

### Fatal olmayan iddiadan sonra nil dereference (71 yer, 17 dosya)

```go
if err == nil {
    t.Error("expected error ...")
}
if !strings.Contains(err.Error(), "...") {   // err burada nil
```

`t.Error` testi başarısız işaretler ama **durdurmaz**. Bu desen tam olarak test düştüğü anda panikliyor, iddia mesajının yerine bir yığın izi koyuyor — ve paket düzeyinde bir panikte diğer bütün hataları da gizliyor.

Artık `t.Fatal`/`t.Fatalf`. Yalnızca hem `t.Error` ile bildiren hem de ardından kontrol edilen değeri dereference eden bloklara dokunuldu; tarama betiği ve dört noktalık elle doğrulama ile seçildi.

`server_lifecycle_cov_test.go` gofmt'li değildi.

### Sonuç

Takım macOS'ta artık sonuna kadar koşuyor. Yeşil değil — ve bu iyi haber: değişiklik, bir paniğin yuttuğu **sekiz mevcut `internal/backup` restore hatasını görünür kıldı**. Daha önce 3 satır görünüyordu, şimdi 8.

Bunlar ayrı hatalar, ayrı ele alınıyor:

- `internal/backup` restore hataları → #68
- `TestGitAuthEnv_WithToken` — `GIT_ASKPASS` `/bin/true`'ya sabitlenmiş, macOS'ta o dosya yok (`internal/admin/deploy/git.go:286`)
- `internal/admin` 600 sn zaman aşımı

Bu PR yalnızca test dosyalarına dokunuyor; ürün kodunda değişiklik yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
