### PR TITLE
fix(php): açılışta başlayan domainlerde oturum/yükleme dizini izolasyonu yoktu

### DIFF
--- a/internal/phpmanager/domain.go
+++ b/internal/phpmanager/domain.go
@@ -619,7 +619,22 @@ func (m *Manager) buildDomainINI(domain string, inst PHPInstall, overrides map[s
 		if domainInst.webRoot != "" {
 			// Per-domain tmp directory for session/upload isolation
 			domainTmp := filepath.Join(domainInst.webRoot, ".tmp")
-			os.MkdirAll(domainTmp, 0770)
+			// Sessions move here from wherever the base php.ini kept them
+			// (PHP's default is the shared system temp directory). Everyone
+			// logged in to this site is signed out once, on the restart that
+			// first applies it — say so rather than leaving the operator to
+			// discover it from support tickets.
+			if _, err := os.Stat(domainTmp); os.IsNotExist(err) {
+				m.logger.Info("isolating PHP sessions and uploads for this domain; existing sessions elsewhere will not be visible and users will be signed out once",
+					"domain", domain, "dir", domainTmp)
+			}
+			if err := os.MkdirAll(domainTmp, 0770); err != nil {
+				// Without a writable directory PHP cannot write sessions at
+				// all, which is worse than sharing one — the ini below points
+				// session.save_path at it regardless, so this must be loud.
+				m.logger.Error("per-domain session directory could not be created; PHP sessions will fail for this domain",
+					"domain", domain, "dir", domainTmp, "error", err)
+			}
 			// open_basedir paths:
 			// - domain web root (site files)
 			// - domain .tmp (sessions, uploads, temp)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1228,13 +1228,9 @@ func (s *Server) autoAssignPHP(phpMgr *phpmanager.Manager, cfg *config.Config) {
 			s.logger.Warn("configured PHP address unreachable, re-assigning", "domain", d.Host, "address", d.PHP.FPMAddress)
 		}
 
-		inst, err := phpMgr.AssignDomain(d.Host, defaultVer)
+		inst, err := assignPHPForDomain(phpMgr, d, defaultVer, s.logger)
 		if err != nil {
-			continue // already assigned
-		}
-		if err := phpMgr.StartDomain(d.Host); err != nil {
-			s.logger.Warn("PHP auto-start failed", "domain", d.Host, "error", err)
-			continue
+			continue // already assigned, or start failed (logged)
 		}
 		// Sync FPM address in config.
 		for i := range cfg.Domains {
@@ -1245,6 +1241,52 @@ func (s *Server) autoAssignPHP(phpMgr *phpmanager.Manager, cfg *config.Config) {
 		}
 		s.logger.Info("PHP assigned to domain", "domain", d.Host, "version", defaultVer, "listen", inst.ListenAddr)
 	}
+}
+
+// phpAssigner is the slice of the PHP manager that autoAssignPHP needs. It
+// exists so the wiring below can be tested: the real manager only reports PHP
+// versions it detected on the host, which a test cannot supply.
+type phpAssigner interface {
+	AssignDomainWithRoot(domain, version, webRoot string) (*phpmanager.DomainPHP, error)
+	SetDomainConfig(domain, key, value string) error
+	StartDomain(domain string) error
+}
+
+// assignPHPForDomain assigns PHP to one domain and starts it.
+//
+// The web root and the domain's php.ini overrides must be handed over before
+// the process starts, because buildDomainINI reads both when it writes the
+// per-domain ini. This path used to call AssignDomain, which leaves the web
+// root empty — and buildDomainINI gates the whole open_basedir /
+// upload_tmp_dir / session.save_path block on a non-empty web root. Every PHP
+// domain started at boot therefore ran with no filesystem isolation and
+// shared the system temp directory for sessions and uploads, while the same
+// domain re-assigned through the admin panel (which calls
+// AssignDomainWithRoot) got both. The domain's ConfigOverrides were dropped
+// on this path too.
+func assignPHPForDomain(phpMgr phpAssigner, d config.Domain, version string, log *logger.Logger) (*phpmanager.DomainPHP, error) {
+	inst, err := phpMgr.AssignDomainWithRoot(d.Host, version, d.Root)
+	if err != nil {
+		return nil, err
+	}
+	if d.Root == "" {
+		log.Warn("PHP domain has no root; open_basedir cannot be enforced", "domain", d.Host)
+	}
+
+	// SetDomainConfig validates each key, so a rejected override is reported
+	// rather than silently dropped — and does not stop the others.
+	for key, value := range d.PHP.ConfigOverrides {
+		if err := phpMgr.SetDomainConfig(d.Host, key, value); err != nil {
+			log.Warn("per-domain php.ini override rejected",
+				"domain", d.Host, "key", key, "error", err)
+		}
+	}
+
+	if err := phpMgr.StartDomain(d.Host); err != nil {
+		log.Warn("PHP auto-start failed", "domain", d.Host, "error", err)
+		return nil, err
+	}
+	return inst, nil
 }
 
 func configHasPHPDomains(cfg *config.Config) bool {

--- a/internal/server/server_php_openbasedir_test.go
+++ b/internal/server/server_php_openbasedir_test.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/config"
+	"github.com/uwaserver/uwas/internal/logger"
+	"github.com/uwaserver/uwas/internal/phpmanager"
+)
+
+// autoAssignPHP called AssignDomain, which leaves the web root empty.
+// buildDomainINI gates upload_tmp_dir, session.save_path and sys_temp_dir on
+// a non-empty web root, so a PHP domain started at boot kept the shared
+// system temp directory for sessions and uploads. (open_basedir survives:
+// fastcgi/env.go writes it per request.) The same domain re-assigned through
+// the admin panel went through AssignDomainWithRoot and got the isolation —
+// it depended on which code path happened to start the process.
+
+type sahtePHPYonetici struct {
+	atananKok  map[string]string
+	ayarlar    map[string]map[string]string
+	baslatilan []string
+	// sıra: SetDomainConfig çağrılarının StartDomain'den önce gelmesi şart,
+	// çünkü ini süreç başlarken yazılıyor.
+	baslatildiktanSonraAyar bool
+	atamaHatasi             error
+	ayarHatasi              error
+}
+
+func yeniSahte() *sahtePHPYonetici {
+	return &sahtePHPYonetici{
+		atananKok: map[string]string{},
+		ayarlar:   map[string]map[string]string{},
+	}
+}
+
+func (f *sahtePHPYonetici) AssignDomainWithRoot(domain, version, webRoot string) (*phpmanager.DomainPHP, error) {
+	if f.atamaHatasi != nil {
+		return nil, f.atamaHatasi
+	}
+	f.atananKok[domain] = webRoot
+	return &phpmanager.DomainPHP{Domain: domain, Version: version, ListenAddr: "127.0.0.1:9001"}, nil
+}
+
+func (f *sahtePHPYonetici) SetDomainConfig(domain, key, value string) error {
+	for _, d := range f.baslatilan {
+		if d == domain {
+			f.baslatildiktanSonraAyar = true
+		}
+	}
+	if f.ayarHatasi != nil {
+		return f.ayarHatasi
+	}
+	if f.ayarlar[domain] == nil {
+		f.ayarlar[domain] = map[string]string{}
+	}
+	f.ayarlar[domain][key] = value
+	return nil
+}
+
+func (f *sahtePHPYonetici) StartDomain(domain string) error {
+	f.baslatilan = append(f.baslatilan, domain)
+	return nil
+}
+
+func testLog() *logger.Logger { return logger.New("error", "text") }
+
+// The web root must reach the PHP manager, or open_basedir is never written.
+func TestAssignPHPForDomainPassesWebRoot(t *testing.T) {
+	f := yeniSahte()
+	d := config.Domain{Host: "php.test", Type: "php", Root: "/srv/www/php.test"}
+
+	if _, err := assignPHPForDomain(f, d, "8.4", testLog()); err != nil {
+		t.Fatalf("assignPHPForDomain: %v", err)
+	}
+
+	if got := f.atananKok["php.test"]; got != "/srv/www/php.test" {
+		t.Errorf("web root = %q, want %q — boş kök oturum/yükleme izolasyonunu kapatır", got, "/srv/www/php.test")
+	}
+	if len(f.baslatilan) != 1 || f.baslatilan[0] != "php.test" {
+		t.Errorf("StartDomain çağrıları = %v", f.baslatilan)
+	}
+}
+
+// The domain's php.ini overrides were dropped on this path entirely.
+func TestAssignPHPForDomainAppliesConfigOverrides(t *testing.T) {
+	f := yeniSahte()
+	d := config.Domain{
+		Host: "php.test",
+		Type: "php",
+		Root: "/srv/www/php.test",
+		PHP: config.PHPConfig{
+			ConfigOverrides: map[string]string{
+				"memory_limit":        "256M",
+				"upload_max_filesize": "32M",
+			},
+		},
+	}
+
+	if _, err := assignPHPForDomain(f, d, "8.4", testLog()); err != nil {
+		t.Fatalf("assignPHPForDomain: %v", err)
+	}
+
+	got := f.ayarlar["php.test"]
+	if got["memory_limit"] != "256M" || got["upload_max_filesize"] != "32M" {
+		t.Errorf("uygulanan override'lar = %v", got)
+	}
+	// buildDomainINI ini'yi süreç başlarken yazıyor; sonradan set edilen bir
+	// override o sürece hiç ulaşmaz.
+	if f.baslatildiktanSonraAyar {
+		t.Error("override StartDomain'den sonra set edildi — çalışan sürece ulaşmaz")
+	}
+}
+
+// A rejected override must not take the rest, or the start, down with it.
+func TestAssignPHPForDomainSurvivesRejectedOverride(t *testing.T) {
+	f := yeniSahte()
+	f.ayarHatasi = errors.New("disallowed key")
+	d := config.Domain{
+		Host: "php.test",
+		Type: "php",
+		Root: "/srv/www/php.test",
+		PHP:  config.PHPConfig{ConfigOverrides: map[string]string{"open_basedir": "/"}},
+	}
+
+	if _, err := assignPHPForDomain(f, d, "8.4", testLog()); err != nil {
+		t.Fatalf("reddedilen override atamayı düşürdü: %v", err)
+	}
+	if len(f.baslatilan) != 1 {
+		t.Error("reddedilen override StartDomain'i engelledi")
+	}
+}
+
+// An already-assigned domain must not be started a second time.
+func TestAssignPHPForDomainStopsOnAssignError(t *testing.T) {
+	f := yeniSahte()
+	f.atamaHatasi = errors.New("domain already has a PHP assignment")
+
+	if _, err := assignPHPForDomain(f, config.Domain{Host: "php.test"}, "8.4", testLog()); err == nil {
+		t.Fatal("atama hatası yutuldu")
+	}
+	if len(f.baslatilan) != 0 {
+		t.Errorf("atama başarısızken StartDomain çağrıldı: %v", f.baslatilan)
+	}
+}


### PR DESCRIPTION
> **Düzeltme (ilk açıklama yanlıştı).** İlk yazdığım "PHP domainleri dosya sistemi izolasyonu olmadan koşuyor" ifadesi hatalıydı. `open_basedir` **uygulanıyor** — `internal/handler/fastcgi/env.go:95-110` her istekte `PHP_ADMIN_VALUE` üzerinden yazıyor, `buildDomainINI`'den bağımsız olarak. Aşağısı gerçekte eksik olanı anlatıyor.

`autoAssignPHP`, `AssignDomain` çağırıyordu; bu fonksiyon domainin web kökünü boş bırakıyor. `buildDomainINI` ise şu bloğu boş olmayan bir web köküne bağlamış:

```go
if domainInst.webRoot != "" {
    lines = append(lines, fmt.Sprintf("open_basedir = %s:%s:...", domainInst.webRoot, domainTmp))
    lines = append(lines, fmt.Sprintf("upload_tmp_dir = %s", domainTmp))
    lines = append(lines, fmt.Sprintf("session.save_path = %s", domainTmp))
    lines = append(lines, fmt.Sprintf("sys_temp_dir = %s", domainTmp))
}
```

Dört satırdan üçünün başka bir kaynağı yok:

| direktif | boot yolunda | not |
|---|---|---|
| `open_basedir` | **uygulanıyor** | `PHP_ADMIN_VALUE` her istekte yazıyor |
| `upload_tmp_dir` | eksik | paylaşılan sistem temp'i |
| `session.save_path` | eksik | paylaşılan oturum dizini |
| `sys_temp_dir` | eksik | paylaşılan sistem temp'i |

### Neden önemli

`open_basedir` listesi `/tmp`'yi içeriyor (`env.go:101`). Boot yolunda `session.save_path` domainin `.tmp`'sine yönlendirilmediği için oturum dosyaları paylaşılan dizine düşüyor — ve orası her domainin `open_basedir`'inin izin verdiği bir yer. Paylaşımlı barındırmada bu, bir domainin PHP'sinin başka bir domainin oturum dosyalarını okuyabilmesi demek.

Temel `php.ini` `session.save_path`'i `/var/lib/php/sessions` gibi bir yere ayarlamışsa sonuç diğer uç: o yol `open_basedir` dışında kalır ve oturumlar hiç yazılamaz.

Aynı domain admin panelinden yeniden atandığında `AssignDomainWithRoot`'tan geçip izolasyonu alıyor — yani davranış süreci hangi kod yolunun başlattığına bağlı, ve bir yeniden başlatma onu geri alıyor.

`autoAssignPHP`'nin geri yazdığı FPM adresi yalnızca bellekteki config'e işleniyor, diske değil; dolayısıyla YAML'ında `php.fpm_address` sabitlenmemiş bir domain **her açılışta** bu yoldan geçiyor.

Aynı çağrı `d.PHP.ConfigOverrides`'ı da düşürüyordu: domain YAML'ındaki domain-başına `php.ini` ayarları bu yolda yöneticiye hiç ulaşmıyordu.

### Düzeltme

İkisi de `assignPHPForDomain` üzerinden gidiyor. Kök ve override'lar **`StartDomain`'den önce** veriliyor — `buildDomainINI` ini'yi süreç başlarken yazıyor, sonrasında set edilen hiçbir şey ona ulaşmaz. Reddedilen bir override loglanıyor ve kalanlar uygulanmaya devam ediyor; `SetDomainConfig` her anahtarı doğrulamayı sürdürüyor.

### Test edilebilirlik

`autoAssignPHP` daha önce test edilemiyordu: gerçek yönetici yalnızca host üzerinde tespit ettiği PHP sürümlerini bildiriyor ve hiçbir şey teste bir sürüm enjekte etmesine izin vermiyor. Mevcut testler bu yüzden yalnızca "PHP bulunamadı" erken dönüşüne ulaşabiliyordu.

Atama adımı artık üç metotluk bir arayüzün arkasında. Keskinlik ölçüldü — kökü ve override'ları geçirmeyi geri alınca:

```
--- FAIL: TestAssignPHPForDomainPassesWebRoot
    web root = "", want "/srv/www/php.test"
--- FAIL: TestAssignPHPForDomainAppliesConfigOverrides
    uygulanan override'lar = map[]
```

Testler ayrıca sıralamayı (override'lar `StartDomain`'den önce), reddedilen bir override'ın atamayı düşürmediğini ve atama başarısızken `StartDomain`'in çağrılmadığını doğruluyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
