### PR TITLE
fix(resources): domain.resources hiç uygulanmıyordu — ve cgroup kodu da çalışmıyordu

### DIFF
--- a/internal/phpmanager/domain.go
+++ b/internal/phpmanager/domain.go
@@ -15,6 +15,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/uwaserver/uwas/internal/rlimit"
 )
 
 // AssignDomain assigns a PHP version to a domain.
@@ -227,6 +229,30 @@ func (m *Manager) StartDomain(domain string) error {
 		listenAddr: inst.listenAddr,
 	}
 
+	// Place the worker in the domain's cgroup. domain.resources was dead
+	// configuration: internal/rlimit implemented it in full and nothing
+	// imported the package, so cpu_percent / memory_mb / pid_max were
+	// defaulted, merged, echoed back by the API and never enforced.
+	//
+	// A failure here does not stop the domain: a host without cgroup v2, or
+	// UWAS running unprivileged, must still serve PHP. It is logged at error
+	// level because the operator asked for a limit and is not getting it.
+	inst.cgroupPath = ""
+	if cgPath, cgErr := rlimitApply(domain, inst.limits); cgErr != nil {
+		m.logger.Error("resource limits could not be applied; PHP runs unlimited",
+			"domain", domain, "error", cgErr)
+	} else if cgPath != "" {
+		if cgErr := rlimitAssignPID(cgPath, cmd.Process.Pid); cgErr != nil {
+			m.logger.Error("PHP worker could not be moved into its cgroup; it runs unlimited",
+				"domain", domain, "pid", cmd.Process.Pid, "error", cgErr)
+		} else {
+			inst.cgroupPath = cgPath
+			m.logger.Info("resource limits applied", "domain", domain, "cgroup", cgPath,
+				"cpu_percent", inst.limits.CPUPercent, "memory_mb", inst.limits.MemoryMB,
+				"pid_max", inst.limits.PIDMax)
+		}
+	}
+
 	// Capture callback before releasing lock.
 	changeFn := m.onDomainChange
 	listenAddr := inst.listenAddr
@@ -343,7 +369,20 @@ func (m *Manager) StopDomain(domain string) error {
 	inst.proc = nil
 	tmpINI := inst.tmpINI
 	inst.tmpINI = ""
+	hadCgroup := inst.cgroupPath != ""
+	inst.cgroupPath = ""
 	m.domainMu.Unlock()
+
+	// Remove the cgroup once the worker is gone. rmdir fails while the group
+	// still holds processes, so this is best-effort: the next Apply reuses
+	// the directory anyway.
+	if hadCgroup {
+		defer func() {
+			if err := rlimitRemove(domain); err != nil {
+				m.logger.Debug("cgroup not removed", "domain", domain, "error", err)
+			}
+		}()
+	}
 
 	// System FPM socket: no process to kill (managed by systemd)
 	if proc.cmd == nil || proc.cmd.Process == nil {
@@ -442,6 +481,43 @@ func phpINIValueSafe(value string) bool {
 		}
 	}
 	return true
+}
+
+// Indirection over internal/rlimit so the wiring can be tested without a
+// cgroup v2 host. internal/rlimit has its own kernel-level tests.
+var (
+	rlimitApply     = rlimit.Apply
+	rlimitAssignPID = rlimit.AssignPID
+	rlimitRemove    = rlimit.Remove
+)
+
+// SetDomainLimits records the resource limits for a domain. They take effect
+// the next time the domain's PHP worker starts, because a cgroup has to exist
+// before a process can be moved into it.
+//
+// Returns false if the domain has no PHP assignment.
+func (m *Manager) SetDomainLimits(domain string, limits rlimit.Limits) bool {
+	m.domainMu.Lock()
+	defer m.domainMu.Unlock()
+
+	inst, ok := m.domainMap[domain]
+	if !ok {
+		return false
+	}
+	inst.limits = limits
+	return true
+}
+
+// DomainLimits reports the limits recorded for a domain.
+func (m *Manager) DomainLimits(domain string) (rlimit.Limits, bool) {
+	m.domainMu.RLock()
+	defer m.domainMu.RUnlock()
+
+	inst, ok := m.domainMap[domain]
+	if !ok {
+		return rlimit.Limits{}, false
+	}
+	return inst.limits, true
 }
 
 // SetDomainConfig sets a per-domain php.ini override with security validation.

--- a/internal/phpmanager/domain_limits_hooks_test.go
+++ b/internal/phpmanager/domain_limits_hooks_test.go
@@ -1,0 +1,13 @@
+package phpmanager
+
+import "errors"
+
+var errCgroupUnavailable = errors.New("cgroup v2 not available")
+
+// rlimitTestHooks swaps the rlimit indirection and returns a restore func.
+func rlimitTestHooks() func() {
+	origApply, origAssign, origRemove := rlimitApply, rlimitAssignPID, rlimitRemove
+	return func() {
+		rlimitApply, rlimitAssignPID, rlimitRemove = origApply, origAssign, origRemove
+	}
+}

--- a/internal/phpmanager/domain_limits_test.go
+++ b/internal/phpmanager/domain_limits_test.go
@@ -1,0 +1,153 @@
+package phpmanager
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/rlimit"
+)
+
+// domain.resources was dead configuration: internal/rlimit implemented cgroup
+// v2 limits in full and no package ever imported it, so cpu_percent /
+// memory_mb / pid_max were defaulted, merged, echoed back by the admin API
+// and never enforced.
+
+func limitsManager(t *testing.T) *Manager {
+	t.Helper()
+
+	m := New(testLogger())
+	m.installations = []PHPInstall{
+		{Version: "8.4.19", Binary: "/usr/bin/php-cgi8.4", SAPI: "cgi-fcgi"},
+	}
+	m.execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("sleep", "100")
+	}
+	return m
+}
+
+func TestSetDomainLimitsRecordsAndReports(t *testing.T) {
+	m := limitsManager(t)
+	if _, err := m.AssignDomain("limits.test", "8.4"); err != nil {
+		t.Fatalf("AssignDomain: %v", err)
+	}
+
+	want := rlimit.Limits{CPUPercent: 50, MemoryMB: 256, PIDMax: 100}
+	if !m.SetDomainLimits("limits.test", want) {
+		t.Fatal("SetDomainLimits atanmış domain için false döndü")
+	}
+
+	got, ok := m.DomainLimits("limits.test")
+	if !ok {
+		t.Fatal("DomainLimits atanmış domain için false döndü")
+	}
+	if got != want {
+		t.Errorf("limitler = %+v, want %+v", got, want)
+	}
+}
+
+func TestSetDomainLimitsUnknownDomain(t *testing.T) {
+	m := limitsManager(t)
+	if m.SetDomainLimits("yok.test", rlimit.Limits{MemoryMB: 64}) {
+		t.Error("atanmamış domain için true döndü")
+	}
+	if _, ok := m.DomainLimits("yok.test"); ok {
+		t.Error("atanmamış domain için limit bildirildi")
+	}
+}
+
+// StartDomain must ask rlimit to build the cgroup with the recorded limits,
+// and must move the worker it just started into it.
+func TestStartDomainAppliesRecordedLimits(t *testing.T) {
+	defer rlimitTestHooks()()
+
+	var (
+		appliedDomain string
+		appliedLimits rlimit.Limits
+		assignedPath  string
+		assignedPID   int
+	)
+	rlimitApply = func(domain string, l rlimit.Limits) (string, error) {
+		appliedDomain, appliedLimits = domain, l
+		return "/sys/fs/cgroup/uwas/" + domain, nil
+	}
+	rlimitAssignPID = func(path string, pid int) error {
+		assignedPath, assignedPID = path, pid
+		return nil
+	}
+
+	m := limitsManager(t)
+	if _, err := m.AssignDomain("limits.test", "8.4"); err != nil {
+		t.Fatalf("AssignDomain: %v", err)
+	}
+	want := rlimit.Limits{CPUPercent: 25, MemoryMB: 512, PIDMax: 64}
+	m.SetDomainLimits("limits.test", want)
+
+	if err := m.StartDomain("limits.test"); err != nil {
+		t.Fatalf("StartDomain: %v", err)
+	}
+	t.Cleanup(func() { _ = m.StopDomain("limits.test") })
+
+	if appliedDomain != "limits.test" || appliedLimits != want {
+		t.Errorf("Apply(%q, %+v), want (%q, %+v)", appliedDomain, appliedLimits, "limits.test", want)
+	}
+	if assignedPath != "/sys/fs/cgroup/uwas/limits.test" {
+		t.Errorf("AssignPID yolu = %q", assignedPath)
+	}
+	if assignedPID == 0 {
+		t.Error("AssignPID çağrılmadı — işçi cgroup dışında koşar")
+	}
+}
+
+// A host without cgroups must still serve PHP.
+func TestStartDomainSurvivesLimitFailure(t *testing.T) {
+	defer rlimitTestHooks()()
+	rlimitApply = func(string, rlimit.Limits) (string, error) {
+		return "", errCgroupUnavailable
+	}
+
+	m := limitsManager(t)
+	if _, err := m.AssignDomain("limits.test", "8.4"); err != nil {
+		t.Fatalf("AssignDomain: %v", err)
+	}
+	m.SetDomainLimits("limits.test", rlimit.Limits{MemoryMB: 128})
+
+	if err := m.StartDomain("limits.test"); err != nil {
+		t.Fatalf("cgroup hatası domaini düşürdü: %v", err)
+	}
+	t.Cleanup(func() { _ = m.StopDomain("limits.test") })
+
+	if m.RunningAddrForDomain("limits.test") == "" {
+		t.Error("cgroup uygulanamayınca PHP başlatılmadı")
+	}
+}
+
+// No limits configured: nothing should be created.
+func TestStartDomainWithoutLimitsCreatesNoCgroup(t *testing.T) {
+	defer rlimitTestHooks()()
+
+	called := false
+	rlimitApply = func(domain string, l rlimit.Limits) (string, error) {
+		called = true
+		if l != (rlimit.Limits{}) {
+			t.Errorf("boş limitler bekleniyordu, alınan %+v", l)
+		}
+		return "", nil // rlimit.Apply boş limitlerde "" döner
+	}
+	rlimitAssignPID = func(string, int) error {
+		t.Error("cgroup yokken AssignPID çağrıldı")
+		return nil
+	}
+
+	m := limitsManager(t)
+	if _, err := m.AssignDomain("plain.test", "8.4"); err != nil {
+		t.Fatalf("AssignDomain: %v", err)
+	}
+	if err := m.StartDomain("plain.test"); err != nil {
+		t.Fatalf("StartDomain: %v", err)
+	}
+	t.Cleanup(func() { _ = m.StopDomain("plain.test") })
+
+	if !called {
+		t.Error("Apply hiç çağrılmadı")
+	}
+}

--- a/internal/phpmanager/manager.go
+++ b/internal/phpmanager/manager.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/uwaserver/uwas/internal/logger"
+
+	"github.com/uwaserver/uwas/internal/rlimit"
 )
 
 // Testable hooks for OS operations. Overridden in tests.
@@ -76,8 +78,13 @@ type domainInstance struct {
 	listenAddr      string
 	webRoot         string // domain document root for open_basedir
 	configOverrides map[string]string
-	proc            *processInfo
-	tmpINI          string // path to temp ini file, cleaned up on stop
+	// Per-domain resource limits (Linux cgroups v2). cgroupPath is the
+	// cgroup Apply created for this domain, or "" when no limits are set or
+	// the platform has no cgroups.
+	limits     rlimit.Limits
+	cgroupPath string
+	proc       *processInfo
+	tmpINI     string // path to temp ini file, cleaned up on stop
 	// crash-restart tracking: prevent a permanently-broken PHP binary from
 	// looping start→crash→start every 500ms forever.
 	restartCount int

--- a/internal/rlimit/cgroup.go
+++ b/internal/rlimit/cgroup.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 )
 
 const cgroupBase = "/sys/fs/cgroup/uwas"
@@ -16,6 +17,7 @@ const cgroupBase = "/sys/fs/cgroup/uwas"
 var (
 	osMkdirAllFn  = os.MkdirAll
 	osWriteFileFn = os.WriteFile
+	osReadFileFn  = os.ReadFile
 	osRemoveFn    = os.Remove
 	runtimeGOOS   = func() string { return runtime.GOOS }
 )
@@ -39,6 +41,17 @@ func Apply(domain string, limits Limits) (cgroupPath string, err error) {
 	}
 	if limits.CPUPercent == 0 && limits.MemoryMB == 0 && limits.PIDMax == 0 {
 		return "", nil
+	}
+
+	if err := osMkdirAllFn(cgroupBase, 0755); err != nil {
+		return "", fmt.Errorf("create cgroup %s: %w", cgroupBase, err)
+	}
+	// A child cgroup only gets cpu.max / memory.max / pids.max if the parent
+	// enables those controllers for its children. Without this the child is
+	// created with nothing but cgroup.* and *.pressure files, and every write
+	// below fails with EACCES — the limits silently do not exist.
+	if err := enableControllers(cgroupBase, limits); err != nil {
+		return "", err
 	}
 
 	path := filepath.Join(cgroupBase, sanitizeDomain(domain))
@@ -102,4 +115,56 @@ func sanitizeDomain(domain string) string {
 		}
 	}
 	return string(safe)
+}
+
+// controllersFor returns the cgroup v2 controllers the given limits need.
+func controllersFor(limits Limits) []string {
+	var out []string
+	if limits.CPUPercent > 0 {
+		out = append(out, "cpu")
+	}
+	if limits.MemoryMB > 0 {
+		out = append(out, "memory")
+	}
+	if limits.PIDMax > 0 {
+		out = append(out, "pids")
+	}
+	return out
+}
+
+// enableControllers delegates the controllers a domain needs to the children
+// of base, writing only the ones that are not already enabled.
+//
+// The kernel refuses a controller that the base cgroup itself was not granted
+// (its own parent must list it in cgroup.subtree_control). That is reported
+// rather than silently producing a cgroup with no limit files in it.
+func enableControllers(base string, limits Limits) error {
+	need := controllersFor(limits)
+	if len(need) == 0 {
+		return nil
+	}
+
+	enabled := map[string]bool{}
+	if data, err := osReadFileFn(filepath.Join(base, "cgroup.subtree_control")); err == nil {
+		for _, c := range strings.Fields(string(data)) {
+			enabled[c] = true
+		}
+	}
+
+	var missing []string
+	for _, c := range need {
+		if !enabled[c] {
+			missing = append(missing, "+"+c)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	target := filepath.Join(base, "cgroup.subtree_control")
+	if err := osWriteFileFn(target, []byte(strings.Join(missing, " ")), 0644); err != nil {
+		return fmt.Errorf("enable cgroup controllers %s in %s: %w (is cgroup v2 mounted, and are these controllers delegated to %s?)",
+			strings.Join(missing, " "), target, err, base)
+	}
+	return nil
 }

--- a/internal/rlimit/cgroup_kernel_test.go
+++ b/internal/rlimit/cgroup_kernel_test.go
@@ -1,0 +1,160 @@
+//go:build linux
+
+package rlimit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These run against the real kernel, not the hooks. They are the only proof
+// that Apply produces a cgroup the kernel actually enforces: the hook-based
+// tests happily passed while Apply created a cgroup with no cpu.max,
+// memory.max or pids.max in it at all, because it never delegated the
+// controllers through the parent's cgroup.subtree_control.
+//
+// Requires cgroup v2 and root. Run them with:
+//
+//	docker run --rm --privileged --cgroupns=host -v "$PWD":/src -w /src \
+//	  golang:1.26 go test ./internal/rlimit/ -run Kernel -v
+
+func requireCgroup2Root(t *testing.T) {
+	t.Helper()
+
+	if os.Geteuid() != 0 {
+		t.Skip("cgroup v2 yazımı root gerektirir")
+	}
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err != nil {
+		t.Skip("cgroup v2 bağlı değil")
+	}
+}
+
+func TestKernelApplyEnforcesLimits(t *testing.T) {
+	requireCgroup2Root(t)
+
+	const domain = "kernel-test.example"
+	t.Cleanup(func() { _ = Remove(domain) })
+
+	path, err := Apply(domain, Limits{CPUPercent: 50, MemoryMB: 100, PIDMax: 42})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if path == "" {
+		t.Fatal("Apply boş yol döndürdü")
+	}
+
+	// Read the values back from the kernel, not from a recording hook.
+	want := map[string]string{
+		"cpu.max":    "50000 100000",
+		"memory.max": "104857600",
+		"pids.max":   "42",
+	}
+	for file, expected := range want {
+		data, err := os.ReadFile(filepath.Join(path, file))
+		if err != nil {
+			t.Errorf("%s okunamadı: %v — denetleyici üst cgroup'a devredilmemiş", file, err)
+			continue
+		}
+		if got := strings.TrimSpace(string(data)); got != expected {
+			t.Errorf("%s = %q, want %q", file, got, expected)
+		}
+	}
+}
+
+// A process assigned to the cgroup must actually appear in it.
+func TestKernelAssignPIDMovesProcess(t *testing.T) {
+	requireCgroup2Root(t)
+
+	const domain = "kernel-assign.example"
+	t.Cleanup(func() { _ = Remove(domain) })
+
+	path, err := Apply(domain, Limits{PIDMax: 64})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("süreç başlatılamadı: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	if err := AssignPID(path, cmd.Process.Pid); err != nil {
+		t.Fatalf("AssignPID: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(path, "cgroup.procs"))
+	if err != nil {
+		t.Fatalf("cgroup.procs okunamadı: %v", err)
+	}
+	found := false
+	for _, line := range strings.Fields(string(data)) {
+		if line == itoa(cmd.Process.Pid) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("PID %d cgroup'ta yok; üyeler: %q", cmd.Process.Pid, strings.TrimSpace(string(data)))
+	}
+}
+
+// The memory limit must be enforced, not merely written: a process that asks
+// for more than its cap must be killed by the kernel.
+func TestKernelMemoryLimitIsEnforced(t *testing.T) {
+	requireCgroup2Root(t)
+
+	const domain = "kernel-oom.example"
+	t.Cleanup(func() { _ = Remove(domain) })
+
+	path, err := Apply(domain, Limits{MemoryMB: 16})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// Without this the kernel swaps instead of killing, and the test hangs.
+	if err := os.WriteFile(filepath.Join(path, "memory.swap.max"), []byte("0"), 0o644); err != nil {
+		t.Skipf("memory.swap.max ayarlanamadı: %v", err)
+	}
+
+	// Allocate well past the cap. sh reads the whole string into memory.
+	cmd := exec.Command("sh", "-c", `exec sh -c 'A=""; while :; do A="$A$(head -c 1000000 /dev/zero | tr "\0" "x")"; done'`)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("süreç başlatılamadı: %v", err)
+	}
+	if err := AssignPID(path, cmd.Process.Pid); err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("AssignPID: %v", err)
+	}
+
+	bitti := make(chan error, 1)
+	go func() { bitti <- cmd.Wait() }()
+
+	select {
+	case err := <-bitti:
+		// Killed by the OOM killer, or the shell died trying. Either way the
+		// cap held; an unlimited process would still be running.
+		t.Logf("süreç sonlandı: %v", err)
+	case <-time.After(20 * time.Second):
+		_ = cmd.Process.Kill()
+		<-bitti
+		t.Error("16MB sınırı altındaki süreç sınırsız bellek ayırmaya devam etti")
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/rlimit/cgroup_test.go
+++ b/internal/rlimit/cgroup_test.go
@@ -58,8 +58,10 @@ func TestApplyLinuxWritesConfiguredLimits(t *testing.T) {
 	if !strings.Contains(path, "test.com") {
 		t.Errorf("path = %q, want sanitized domain", path)
 	}
-	if len(mkdirCalls) != 1 {
-		t.Errorf("mkdir calls = %d, want 1", len(mkdirCalls))
+	// Both the base cgroup and the domain's own are created: the base has to
+	// exist before its cgroup.subtree_control can delegate the controllers.
+	if len(mkdirCalls) != 2 {
+		t.Errorf("mkdir calls = %v, want [%s, %s/test.com]", mkdirCalls, cgroupBase, cgroupBase)
 	}
 
 	want := map[string]string{
@@ -300,11 +302,13 @@ func TestRemoveError(t *testing.T) {
 func saveAndRestoreHooks() func() {
 	origOsMkdirAll := osMkdirAllFn
 	origOsWriteFile := osWriteFileFn
+	origOsReadFile := osReadFileFn
 	origOsRemove := osRemoveFn
 	origRuntimeGOOS := runtimeGOOS
 	return func() {
 		osMkdirAllFn = origOsMkdirAll
 		osWriteFileFn = origOsWriteFile
+		osReadFileFn = origOsReadFile
 		osRemoveFn = origOsRemove
 		runtimeGOOS = origRuntimeGOOS
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,6 +51,7 @@ import (
 	"github.com/uwaserver/uwas/internal/monitor"
 	"github.com/uwaserver/uwas/internal/phpmanager"
 	"github.com/uwaserver/uwas/internal/rewrite"
+	"github.com/uwaserver/uwas/internal/rlimit"
 	"github.com/uwaserver/uwas/internal/router"
 	"github.com/uwaserver/uwas/internal/sftpserver"
 	uwastls "github.com/uwaserver/uwas/internal/tls"
@@ -1221,6 +1222,13 @@ func (s *Server) autoAssignPHP(phpMgr *phpmanager.Manager, cfg *config.Config) {
 		if d.PHP.FPMAddress != "" && isAddrReachable(d.PHP.FPMAddress) {
 			// Register in phpMgr so it shows in PHP page domain list
 			phpMgr.RegisterExistingDomain(d.Host, defaultVer, d.PHP.FPMAddress, d.Root, d.PHP.ConfigOverrides)
+			// The pool belongs to systemd, not to UWAS, so its workers cannot
+			// be moved into a UWAS cgroup. Say so rather than leaving the
+			// operator to believe domain.resources is in force.
+			if hasResourceLimits(d.Resources) {
+				s.logger.Warn("domain.resources cannot be enforced for a domain served by an external PHP-FPM pool",
+					"domain", d.Host, "address", d.PHP.FPMAddress)
+			}
 			s.logger.Info("using configured PHP address", "domain", d.Host, "address", d.PHP.FPMAddress)
 			continue
 		}
@@ -1249,28 +1257,34 @@ func (s *Server) autoAssignPHP(phpMgr *phpmanager.Manager, cfg *config.Config) {
 type phpAssigner interface {
 	AssignDomainWithRoot(domain, version, webRoot string) (*phpmanager.DomainPHP, error)
 	SetDomainConfig(domain, key, value string) error
+	SetDomainLimits(domain string, limits rlimit.Limits) bool
 	StartDomain(domain string) error
 }
 
 // assignPHPForDomain assigns PHP to one domain and starts it.
 //
-// The web root and the domain's php.ini overrides must be handed over before
-// the process starts, because buildDomainINI reads both when it writes the
-// per-domain ini. This path used to call AssignDomain, which leaves the web
-// root empty — and buildDomainINI gates the whole open_basedir /
-// upload_tmp_dir / session.save_path block on a non-empty web root. Every PHP
-// domain started at boot therefore ran with no filesystem isolation and
-// shared the system temp directory for sessions and uploads, while the same
-// domain re-assigned through the admin panel (which calls
-// AssignDomainWithRoot) got both. The domain's ConfigOverrides were dropped
-// on this path too.
+// The web root, the domain's php.ini overrides and its resource limits must
+// all be handed over before the process starts: buildDomainINI reads the
+// first two when it writes the per-domain ini, and a cgroup has to exist
+// before a process can be moved into it.
+//
+// This path used to call AssignDomain, which leaves the web root empty, and
+// buildDomainINI gates upload_tmp_dir, session.save_path and sys_temp_dir on
+// a non-empty web root. (open_basedir has a second source: fastcgi/env.go
+// writes it per request.) A domain started at boot therefore kept the shared
+// system temp directory for sessions and uploads, which the open_basedir list
+// permits — so one domain could read another's session files. The same domain
+// re-assigned through the admin panel got the isolation. The domain's
+// ConfigOverrides were dropped here too, and its resource limits were never
+// recorded at all.
 func assignPHPForDomain(phpMgr phpAssigner, d config.Domain, version string, log *logger.Logger) (*phpmanager.DomainPHP, error) {
 	inst, err := phpMgr.AssignDomainWithRoot(d.Host, version, d.Root)
 	if err != nil {
 		return nil, err
 	}
 	if d.Root == "" {
-		log.Warn("PHP domain has no root; open_basedir cannot be enforced", "domain", d.Host)
+		log.Warn("PHP domain has no root; session and upload directories cannot be isolated",
+			"domain", d.Host)
 	}
 
 	// SetDomainConfig validates each key, so a rejected override is reported
@@ -1282,11 +1296,32 @@ func assignPHPForDomain(phpMgr phpAssigner, d config.Domain, version string, log
 		}
 	}
 
+	phpMgr.SetDomainLimits(d.Host, limitsFor(d.Resources))
+
 	if err := phpMgr.StartDomain(d.Host); err != nil {
 		log.Warn("PHP auto-start failed", "domain", d.Host, "error", err)
 		return nil, err
 	}
 	return inst, nil
+}
+
+// limitsFor converts a domain's resource block into the rlimit form.
+//
+// domain.resources was dead configuration: internal/rlimit implemented cgroup
+// v2 limits in full — Apply, AssignPID, Remove, with tests — and no package
+// ever imported it. cpu_percent, memory_mb and pid_max were defaulted,
+// merged, echoed back by the admin API, and never enforced.
+func limitsFor(r config.ResourceLimits) rlimit.Limits {
+	return rlimit.Limits{
+		CPUPercent: r.CPUPercent,
+		MemoryMB:   r.MemoryMB,
+		PIDMax:     r.PIDMax,
+	}
+}
+
+// hasResourceLimits reports whether the operator asked for any limit.
+func hasResourceLimits(r config.ResourceLimits) bool {
+	return r.CPUPercent > 0 || r.MemoryMB > 0 || r.PIDMax > 0
 }
 
 func configHasPHPDomains(cfg *config.Config) bool {

--- a/internal/server/server_php_openbasedir_test.go
+++ b/internal/server/server_php_openbasedir_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/uwaserver/uwas/internal/config"
 	"github.com/uwaserver/uwas/internal/logger"
 	"github.com/uwaserver/uwas/internal/phpmanager"
+	"github.com/uwaserver/uwas/internal/rlimit"
 )
 
 // autoAssignPHP called AssignDomain, which leaves the web root empty.
@@ -20,6 +21,7 @@ import (
 type sahtePHPYonetici struct {
 	atananKok  map[string]string
 	ayarlar    map[string]map[string]string
+	limitler   map[string]rlimit.Limits
 	baslatilan []string
 	// sıra: SetDomainConfig çağrılarının StartDomain'den önce gelmesi şart,
 	// çünkü ini süreç başlarken yazılıyor.
@@ -32,6 +34,7 @@ func yeniSahte() *sahtePHPYonetici {
 	return &sahtePHPYonetici{
 		atananKok: map[string]string{},
 		ayarlar:   map[string]map[string]string{},
+		limitler:  map[string]rlimit.Limits{},
 	}
 }
 
@@ -57,6 +60,16 @@ func (f *sahtePHPYonetici) SetDomainConfig(domain, key, value string) error {
 	}
 	f.ayarlar[domain][key] = value
 	return nil
+}
+
+func (f *sahtePHPYonetici) SetDomainLimits(domain string, l rlimit.Limits) bool {
+	for _, d := range f.baslatilan {
+		if d == domain {
+			f.baslatildiktanSonraAyar = true
+		}
+	}
+	f.limitler[domain] = l
+	return true
 }
 
 func (f *sahtePHPYonetici) StartDomain(domain string) error {
@@ -142,5 +155,57 @@ func TestAssignPHPForDomainStopsOnAssignError(t *testing.T) {
 	}
 	if len(f.baslatilan) != 0 {
 		t.Errorf("atama başarısızken StartDomain çağrıldı: %v", f.baslatilan)
+	}
+}
+
+// domain.resources must reach the manager, and before the worker starts: a
+// cgroup has to exist before a process can be moved into it.
+func TestAssignPHPForDomainRecordsResourceLimits(t *testing.T) {
+	f := yeniSahte()
+	d := config.Domain{
+		Host:      "php.test",
+		Type:      "php",
+		Root:      "/srv/www/php.test",
+		Resources: config.ResourceLimits{CPUPercent: 40, MemoryMB: 512, PIDMax: 80},
+	}
+
+	if _, err := assignPHPForDomain(f, d, "8.4", testLog()); err != nil {
+		t.Fatalf("assignPHPForDomain: %v", err)
+	}
+
+	want := rlimit.Limits{CPUPercent: 40, MemoryMB: 512, PIDMax: 80}
+	if got := f.limitler["php.test"]; got != want {
+		t.Errorf("kaydedilen limitler = %+v, want %+v — domain.resources yöneticiye ulaşmıyor", got, want)
+	}
+	if f.baslatildiktanSonraAyar {
+		t.Error("limitler StartDomain'den sonra kaydedildi — cgroup süreçten sonra kurulur")
+	}
+}
+
+func TestLimitsForCarriesEveryField(t *testing.T) {
+	got := limitsFor(config.ResourceLimits{CPUPercent: 50, MemoryMB: 256, PIDMax: 100})
+	if want := (rlimit.Limits{CPUPercent: 50, MemoryMB: 256, PIDMax: 100}); got != want {
+		t.Errorf("limitsFor = %+v, want %+v", got, want)
+	}
+	if got := limitsFor(config.ResourceLimits{}); got != (rlimit.Limits{}) {
+		t.Errorf("limitsFor(boş) = %+v", got)
+	}
+}
+
+func TestHasResourceLimits(t *testing.T) {
+	cases := []struct {
+		in   config.ResourceLimits
+		want bool
+	}{
+		{config.ResourceLimits{}, false},
+		{config.ResourceLimits{CPUPercent: 10}, true},
+		{config.ResourceLimits{MemoryMB: 1}, true},
+		{config.ResourceLimits{PIDMax: 1}, true},
+		{config.ResourceLimits{CPUPercent: -1}, false},
+	}
+	for _, c := range cases {
+		if got := hasResourceLimits(c.in); got != c.want {
+			t.Errorf("hasResourceLimits(%+v) = %v, want %v", c.in, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
> **#70 üzerine yığılmış.** Taban dalı `fix/php-openbasedir-boot-path`; #70 birleşince bu PR otomatik olarak `main`'e döner. Aynı dikişi (`assignPHPForDomain`) kullanıyor.

`domain.resources` alışılmadık türden bir ölü ayardı: **`internal/rlimit` cgroup v2 sınırlarını eksiksiz uyguluyordu** — `Apply`, `AssignPID`, `Remove`, testleriyle ve platform korumalarıyla — ve **hiçbir paket onu import etmiyordu.** `cpu_percent`, `memory_mb`, `pid_max` varsayılan atanıyor, birleştiriliyor, admin API'de geri veriliyor, hiç uygulanmıyordu.

### Yalnızca bağlamak yetmezdi

`Apply` domainin cgroup'unu yaratıyor ama denetleyicileri üst cgroup'un `cgroup.subtree_control`'ü üzerinden devretmiyordu. cgroup v2'de bir alt cgroup'ta `cpu.max` / `memory.max` / `pids.max` **ancak** üstü o denetleyicileri çocukları için etkinleştirmişse oluşur. Gerçek çekirdekte doğrulandı:

```
mkdir /sys/fs/cgroup/uwas/test.com
ls    → yalnızca cgroup.* ve *.pressure; cpu.max, memory.max, pids.max YOK
echo "50000 100000" > .../cpu.max
      → sh: can't create ...: Permission denied
```

`Apply` artık taban cgroup'u yaratıp yapılandırılan sınırların gerektirdiği denetleyicileri — zaten etkin olanları atlayarak — etkinleştiriyor. Tabanın kendisine verilmemiş bir denetleyici, sebebiyle birlikte bildiriliyor; içinde hiç sınır dosyası olmayan bir cgroup bırakılmıyor.

### Bağlantı

`phpmanager` her domainin işçisini başlar başlamaz o cgroup'a alıyor, durdurmada cgroup'u kaldırıyor. Hata domaini düşürmüyor — cgroup v2'siz bir host ya da yetkisiz koşan UWAS yine PHP servis etmeli — ama error seviyesinde loglanıyor, çünkü operatör bir sınır istedi ve almıyor.

### Kapsam

Domainin PHP işçileri; UWAS'ın **domain başına** başlattığı tek süreç bu. `internal/apps` uygulamaları ada göre tutuyor ve birden çok domain aynı uygulamaya bağlanabiliyor, dolayısıyla orada "domainin sınırları"nın tek bir cevabı yok — tahmin yürütmek yerine dokunmadım. Harici bir PHP-FPM havuzuyla servis edilen bir domain artık sınırlarının uygulanamayacağı konusunda uyarıyor: o işçiler systemd'nin, UWAS'ın değil.

### Gerçek çekirdek doğrulaması

`internal/rlimit` artık kayıt tutan hook'lara değil **gerçek çekirdeğe** karşı koşan testler içeriyor — hook tabanlı testler, sınırlar hiç var olmadığı süre boyunca geçiyordu. cgroup v2 ve root yoksa atlanıyorlar:

```
docker run --rm --privileged --cgroupns=host -v "$PWD":/src:ro -w /src \
  -e GOTOOLCHAIN=go1.26.6 golang:1.25 \
  go test ./internal/rlimit/ -run Kernel -v
```

Sınırları çekirdekten geri okuyorlar, işçinin `cgroup.procs`'a düştüğünü doğruluyorlar, ve 16MB'lık bir sınırın **fiilen uygulandığını** sürecin öldürülmesini izleyerek doğruluyorlar:

```
--- PASS: TestKernelApplyEnforcesLimits
--- PASS: TestKernelAssignPIDMovesProcess
--- PASS: TestKernelMemoryLimitIsEnforced
    süreç sonlandı: signal: killed
```

Temiz cgroup durumundan, `subtree_control` düzeltmesi olmadan:

```
--- FAIL: TestKernelApplyEnforcesLimits
    Apply: set cpu.max: open /sys/fs/cgroup/uwas/...: permission denied
--- FAIL: TestKernelAssignPIDMovesProcess
    Apply: set pids.max: ... permission denied
--- FAIL: TestKernelMemoryLimitIsEnforced
    Apply: set memory.max: ... permission denied
```

cgroup konteynerden uzun yaşıyor; ilk ölçümüm bu yüzden kirlenmişti (ikinci koşu birincinin denetleyicilerini miras aldı ve yanlışlıkla geçti). Durum koşular arasında temizlenmeli.

### Bağlantı testleri

`limitsFor` kusursuz dönüştürüp `assignPHPForDomain` `SetDomainLimits`'i hiç çağırmayabilir — düzelttiğim hatanın şekli bu. Ayrıca kapsanıyor:

```
--- FAIL: TestAssignPHPForDomainRecordsResourceLimits
    kaydedilen limitler = {CPUPercent:0 MemoryMB:0 PIDMax:0}, want {CPUPercent:40 MemoryMB:512 PIDMax:80}
    — domain.resources yöneticiye ulaşmıyor
```

Sıralama da doğrulanıyor: limitler `StartDomain`'den önce kaydedilmeli, çünkü cgroup süreçten önce var olmalı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
