### PR TITLE
fix(cache): global.cache.vary_by_query hiç okunmuyordu

### DIFF
--- a/internal/cache/engine.go
+++ b/internal/cache/engine.go
@@ -17,6 +17,10 @@ type Engine struct {
 	logger   *logger.Logger
 	varyKeys []string      // precomputed: ["Accept-Encoding", ...configuredVaryHeaders]
 	writeSem chan struct{} // bounds concurrent L2/L3 writes
+	// varyByQuery mirrors global.cache.vary_by_query. It defaults to true —
+	// the key has always included the query string — so an operator has to
+	// ask for the collapse explicitly.
+	varyByQuery bool
 }
 
 // SetVaryHeaders precomput the full vary-key list (Accept-Encoding + caller
@@ -29,14 +33,25 @@ func (e *Engine) SetVaryHeaders(headers []string) {
 	e.varyKeys = keys
 }
 
+// SetVaryByQuery controls whether the query string is part of the cache key.
+//
+// global.cache.vary_by_query was dead configuration: GenerateKey always
+// folded the query in and nothing read the field, so an operator could not
+// collapse /page?utm_source=a and /page?utm_source=b onto one entry however
+// they set it.
+func (e *Engine) SetVaryByQuery(vary bool) {
+	e.varyByQuery = vary
+}
+
 // NewEngine creates a cache engine with memory and optional disk backing.
 // The ctx parameter controls the lifetime of background cleanup goroutines.
 func NewEngine(ctx context.Context, memoryLimit int64, diskPath string, diskLimit int64, log *logger.Logger) *Engine {
 	e := &Engine{
-		memory:   NewMemoryCache(memoryLimit),
-		logger:   log,
-		varyKeys: []string{"Accept-Encoding"}, // default; extended via SetVaryHeaders
-		writeSem: make(chan struct{}, maxConcurrentWrites),
+		memory:      NewMemoryCache(memoryLimit),
+		logger:      log,
+		varyKeys:    []string{"Accept-Encoding"}, // default; extended via SetVaryHeaders
+		writeSem:    make(chan struct{}, maxConcurrentWrites),
+		varyByQuery: true,
 	}
 
 	if diskPath != "" {
@@ -55,16 +70,23 @@ func NewEngine(ctx context.Context, memoryLimit int64, diskPath string, diskLimi
 // should call this once and pass the result to GetByKey / SetByKey to avoid
 // recomputing the key (and reallocating the vary slice) a second time.
 func (e *Engine) Key(r *http.Request) string {
+	return e.key(r)
+}
+
+func (e *Engine) key(r *http.Request) string {
+	if !e.varyByQuery {
+		return GenerateKeyWithoutQuery(r, e.varyKeys)
+	}
 	return GenerateKey(r, e.varyKeys)
 }
 
 // Get looks up a cache entry: L1 (memory) → L2 (disk) → L3 (Redis) → miss.
 func (e *Engine) Get(r *http.Request) (*CachedResponse, string) {
-	return e.GetByKey(GenerateKey(r, e.varyKeys))
+	return e.GetByKey(e.key(r))
 }
 
 func (e *Engine) Set(r *http.Request, resp *CachedResponse) {
-	e.SetByKey(GenerateKey(r, e.varyKeys), resp)
+	e.SetByKey(e.key(r), resp)
 }
 
 // GetByKey looks up a cache entry by explicit key (for ESI fragments).

--- a/internal/cache/key.go
+++ b/internal/cache/key.go
@@ -29,6 +29,17 @@ var builderPool = sync.Pool{
 // Host is normalized: lowercase + port stripped to ensure Example.com:80
 // and example.com produce the same cache key.
 func GenerateKey(r *http.Request, varyHeaders []string) string {
+	return generateKey(r, varyHeaders, true)
+}
+
+// GenerateKeyWithoutQuery builds the key with the query string left out, so
+// requests that differ only in their query share one cache entry. This is
+// what global.cache.vary_by_query: false asks for.
+func GenerateKeyWithoutQuery(r *http.Request, varyHeaders []string) string {
+	return generateKey(r, varyHeaders, false)
+}
+
+func generateKey(r *http.Request, varyHeaders []string, varyByQuery bool) string {
 	b := builderPool.Get().(*strings.Builder)
 	b.Reset()
 
@@ -60,7 +71,7 @@ func GenerateKey(r *http.Request, varyHeaders []string) string {
 	b.WriteByte('|')
 
 	// Sorted query params for consistency (key=a&b and key=b&a → same key).
-	if r.URL.RawQuery != "" {
+	if varyByQuery && r.URL.RawQuery != "" {
 		writeSortedQuery(b, r.URL.RawQuery)
 	}
 

--- a/internal/cache/key_vary_by_query_test.go
+++ b/internal/cache/key_vary_by_query_test.go
@@ -1,0 +1,136 @@
+package cache
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// global.cache.vary_by_query was dead configuration: GenerateKey always folded
+// the query string in and nothing read the field, so an operator could not
+// collapse /page?utm_source=a and /page?utm_source=b onto one entry however
+// they set it.
+
+func istek(path string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	r.Host = "cache.test"
+	return r
+}
+
+func TestGenerateKeyWithoutQueryCollapsesQueries(t *testing.T) {
+	a := GenerateKeyWithoutQuery(istek("/p?utm_source=a"), nil)
+	b := GenerateKeyWithoutQuery(istek("/p?utm_source=b"), nil)
+	if a != b {
+		t.Errorf("sorgular ayrı anahtar üretti:\n  %q\n  %q", a, b)
+	}
+	if plain := GenerateKeyWithoutQuery(istek("/p"), nil); a != plain {
+		t.Errorf("sorgusuz istek farklı anahtar aldı:\n  %q\n  %q", a, plain)
+	}
+	// Different paths must still be different.
+	if other := GenerateKeyWithoutQuery(istek("/q?utm_source=a"), nil); a == other {
+		t.Error("farklı yollar aynı anahtara çöktü")
+	}
+}
+
+// The default must not change: the query has always been part of the key.
+func TestGenerateKeyKeepsQueryByDefault(t *testing.T) {
+	a := GenerateKey(istek("/p?q=cats"), nil)
+	b := GenerateKey(istek("/p?q=dogs"), nil)
+	if a == b {
+		t.Fatal("varsayılan anahtar sorguyu yok saydı — /p?q=kedi ile /p?q=köpek aynı girdiyi paylaşır")
+	}
+}
+
+func testEngine(t *testing.T) *Engine {
+	t.Helper()
+	return NewEngine(context.Background(), 8<<20, "", 0, logger.New("error", "text"))
+}
+
+// girdi builds a live entry. Created must be set: a zero Created puts the
+// expiry in year 1, the entry is never returned, and every "expected a miss"
+// assertion below would pass without testing anything.
+func girdi(body string) *CachedResponse {
+	return &CachedResponse{
+		StatusCode: 200,
+		Body:       []byte(body),
+		Created:    time.Now(),
+		TTL:        time.Minute,
+	}
+}
+
+// saklandiMi guards against exactly that: prove the entry is retrievable
+// before asserting anything about a different request missing it.
+func saklandiMi(t *testing.T, e *Engine, r *http.Request, want string) {
+	t.Helper()
+	got, _ := e.Get(r)
+	if got == nil {
+		t.Fatalf("%s önbelleğe yazılmadı — test boşa geçemez", r.URL)
+	}
+	if string(got.Body) != want {
+		t.Fatalf("gövde = %q, want %q", got.Body, want)
+	}
+}
+
+// A fresh engine must vary by query: absent config means the old behaviour.
+func TestEngineVariesByQueryByDefault(t *testing.T) {
+	e := testEngine(t)
+
+	e.Set(istek("/p?q=cats"), girdi("cats"))
+	saklandiMi(t, e, istek("/p?q=cats"), "cats")
+
+	if got, _ := e.Get(istek("/p?q=dogs")); got != nil {
+		t.Errorf("?q=dogs, ?q=cats'in girdisini aldı: %q", got.Body)
+	}
+}
+
+func TestEngineCollapsesQueriesWhenDisabled(t *testing.T) {
+	e := testEngine(t)
+	e.SetVaryByQuery(false)
+
+	e.Set(istek("/p?utm_source=a"), girdi("sayfa"))
+	saklandiMi(t, e, istek("/p?utm_source=a"), "sayfa")
+
+	got, _ := e.Get(istek("/p?utm_source=b"))
+	if got == nil {
+		t.Fatal("vary_by_query=false iken sorgular ayrı girdilerde kaldı")
+	}
+	if string(got.Body) != "sayfa" {
+		t.Errorf("gövde = %q", got.Body)
+	}
+
+	// Key() must agree with Get/Set, or the store path and the lookup path
+	// would use different keys.
+	if e.Key(istek("/p?utm_source=a")) != e.Key(istek("/p?utm_source=b")) {
+		t.Error("Key() Get/Set ile aynı fikirde değil")
+	}
+}
+
+func TestEngineDisabledStillSeparatesPaths(t *testing.T) {
+	e := testEngine(t)
+	e.SetVaryByQuery(false)
+
+	e.Set(istek("/a?x=1"), girdi("a"))
+	saklandiMi(t, e, istek("/a?x=1"), "a")
+
+	if got, _ := e.Get(istek("/b?x=1")); got != nil {
+		t.Errorf("/b, /a'nın girdisini aldı: %q", got.Body)
+	}
+}
+
+// Turning it back on must restore per-query entries.
+func TestEngineVaryByQueryTogglesBack(t *testing.T) {
+	e := testEngine(t)
+	e.SetVaryByQuery(false)
+	e.SetVaryByQuery(true)
+
+	e.Set(istek("/p?q=cats"), girdi("cats"))
+	saklandiMi(t, e, istek("/p?q=cats"), "cats")
+
+	if got, _ := e.Get(istek("/p?q=dogs")); got != nil {
+		t.Errorf("tekrar açıldıktan sonra da çöktü: %q", got.Body)
+	}
+}

--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -2,17 +2,22 @@ package config
 
 // CacheConfig configures the global HTTP cache (L1 memory + L2 disk + optional L3 Redis).
 type CacheConfig struct {
-	Enabled              bool        `yaml:"enabled"`
-	MemoryLimit          ByteSize    `yaml:"memory_limit"`
-	DiskPath             string      `yaml:"disk_path"`
-	DiskLimit            ByteSize    `yaml:"disk_limit"`
-	DefaultTTL           int         `yaml:"default_ttl"`
-	GraceTTL             int         `yaml:"grace_ttl"`
-	StaleWhileRevalidate bool        `yaml:"stale_while_revalidate"`
-	PurgeKey             string      `yaml:"purge_key"`
-	VaryByQuery          bool        `yaml:"vary_by_query"`   // include query string in cache key
-	VaryByHeaders        []string    `yaml:"vary_by_headers"` // include specific request headers in cache key
-	Redis                RedisConfig `yaml:"redis"`           // L3 Redis cache
+	Enabled              bool     `yaml:"enabled"`
+	MemoryLimit          ByteSize `yaml:"memory_limit"`
+	DiskPath             string   `yaml:"disk_path"`
+	DiskLimit            ByteSize `yaml:"disk_limit"`
+	DefaultTTL           int      `yaml:"default_ttl"`
+	GraceTTL             int      `yaml:"grace_ttl"`
+	StaleWhileRevalidate bool     `yaml:"stale_while_revalidate"`
+	PurgeKey             string   `yaml:"purge_key"`
+	// VaryByQuery is a pointer so an absent setting is distinguishable from an
+	// explicit false. The cache key has always included the query string, and
+	// the field was never read; honouring a zero value literally would make
+	// /search?q=cats and /search?q=dogs share one entry on every deployment
+	// that never set it.
+	VaryByQuery   *bool       `yaml:"vary_by_query,omitempty" json:"vary_by_query,omitempty"`
+	VaryByHeaders []string    `yaml:"vary_by_headers"` // include specific request headers in cache key
+	Redis         RedisConfig `yaml:"redis"`           // L3 Redis cache
 }
 
 // RedisConfig configures the optional L3 Redis cache tier.
@@ -40,4 +45,13 @@ type CacheRule struct {
 	TTL          int    `yaml:"ttl,omitempty" json:"ttl,omitempty"`
 	Bypass       bool   `yaml:"bypass,omitempty" json:"bypass,omitempty"`
 	CacheControl string `yaml:"cache_control,omitempty" json:"cache_control,omitempty"` // Cache-Control header override
+}
+
+// QueryVaries reports whether the query string belongs in the cache key.
+//
+// nil means the operator never mentioned vary_by_query, and the cache key has
+// always included the query — so absent has to mean true. Only an explicit
+// `vary_by_query: false` collapses requests that differ only in their query.
+func (c CacheConfig) QueryVaries() bool {
+	return c.VaryByQuery == nil || *c.VaryByQuery
 }

--- a/internal/config/cache_vary_test.go
+++ b/internal/config/cache_vary_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+// vary_by_query is a pointer so an absent setting is distinguishable from an
+// explicit false. The key has always included the query and the field was
+// never read, so honouring a zero value literally would make /search?q=cats
+// and /search?q=dogs share one entry on every deployment that never set it.
+func TestQueryVaries(t *testing.T) {
+	cases := []struct {
+		ad   string
+		in   *bool
+		want bool
+	}{
+		{"ayarsız (yok) -> varyasyon sürer", nil, true},
+		{"açıkça true", BoolPtr(true), true},
+		{"açıkça false -> çöker", BoolPtr(false), false},
+	}
+	for _, c := range cases {
+		t.Run(c.ad, func(t *testing.T) {
+			if got := (CacheConfig{VaryByQuery: c.in}).QueryVaries(); got != c.want {
+				t.Errorf("QueryVaries() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,6 +209,7 @@ func New(cfg *config.Config, log *logger.Logger) *Server {
 			log,
 		)
 		cacheEngine.SetVaryHeaders(cfg.Global.Cache.VaryByHeaders)
+		cacheEngine.SetVaryByQuery(cfg.Global.Cache.QueryVaries())
 
 		// L3: Redis cache
 		if cfg.Global.Cache.Redis.Enabled {

--- a/internal/server/server_vary_by_query_test.go
+++ b/internal/server/server_vary_by_query_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/config"
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// global.cache.vary_by_query reaching the engine is the half no test would
+// otherwise cover: QueryVaries can be right while nothing calls
+// SetVaryByQuery, which is the shape of the bug being fixed.
+
+func varyFixture(t *testing.T, varyByQuery *bool) (*Server, http.Handler) {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("<!doctype html>sayfa"), 0o644); err != nil {
+		t.Fatalf("yaz: %v", err)
+	}
+
+	cfg := &config.Config{
+		Global: config.GlobalConfig{
+			WorkerCount: "1", LogLevel: "error", LogFormat: "text",
+			Cache: config.CacheConfig{
+				Enabled:     true,
+				MemoryLimit: config.ByteSize(64 << 20),
+				DefaultTTL:  300,
+				VaryByQuery: varyByQuery,
+			},
+		},
+		Domains: []config.Domain{{
+			Host:  "vary.test",
+			Type:  "static",
+			Root:  root,
+			SSL:   config.SSLConfig{Mode: "off"},
+			Cache: config.DomainCache{Enabled: true, TTL: 300},
+		}},
+	}
+
+	s := New(cfg, logger.New("error", "text"))
+	t.Cleanup(func() { s.cancel() })
+	return s, s.buildMiddlewareChain()
+}
+
+func varyIstek(h http.Handler, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = "vary.test"
+	req.Header.Set("User-Agent", "uwas-test")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// saklandi proves the first request actually populated the cache, so the
+// second assertion cannot pass vacuously.
+func saklandi(t *testing.T, s *Server, path string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = "vary.test"
+	if entry, _ := s.cache.Get(req); entry == nil {
+		t.Fatalf("%s önbelleğe yazılmadı — test boşa geçemez", path)
+	}
+}
+
+func TestServerVaryByQueryDefaultsToOn(t *testing.T) {
+	s, h := varyFixture(t, nil) // ayarsız
+
+	if rec := varyIstek(h, "/index.html?a=1"); rec.Code != http.StatusOK {
+		t.Fatalf("durum %d", rec.Code)
+	}
+	saklandi(t, s, "/index.html?a=1")
+
+	req := httptest.NewRequest(http.MethodGet, "/index.html?a=2", nil)
+	req.Host = "vary.test"
+	if entry, _ := s.cache.Get(req); entry != nil {
+		t.Error("ayarsız vary_by_query sorguları çöktürdü — ?a=1 ile ?a=2 aynı girdiyi paylaşır")
+	}
+}
+
+func TestServerVaryByQueryDisabledCollapses(t *testing.T) {
+	s, h := varyFixture(t, config.BoolPtr(false))
+
+	if rec := varyIstek(h, "/index.html?utm_source=a"); rec.Code != http.StatusOK {
+		t.Fatalf("durum %d", rec.Code)
+	}
+	saklandi(t, s, "/index.html?utm_source=a")
+
+	req := httptest.NewRequest(http.MethodGet, "/index.html?utm_source=b", nil)
+	req.Host = "vary.test"
+	if entry, _ := s.cache.Get(req); entry == nil {
+		t.Error("vary_by_query: false motora ulaşmıyor — sorgular ayrı girdilerde kaldı")
+	}
+}
+
+func TestServerVaryByQueryExplicitTrue(t *testing.T) {
+	s, h := varyFixture(t, config.BoolPtr(true))
+
+	if rec := varyIstek(h, "/index.html?a=1"); rec.Code != http.StatusOK {
+		t.Fatalf("durum %d", rec.Code)
+	}
+	saklandi(t, s, "/index.html?a=1")
+
+	req := httptest.NewRequest(http.MethodGet, "/index.html?a=2", nil)
+	req.Host = "vary.test"
+	if entry, _ := s.cache.Get(req); entry != nil {
+		t.Error("açık true sorguları çöktürdü")
+	}
+}


### PR DESCRIPTION
Önbellek anahtarı sorgu dizesini **her zaman** içeriyordu ve ayarı hiçbir yer okumuyordu. Operatör `/page?utm_source=a` ile `/page?utm_source=b`'yi tek girdiye indiremiyordu — alan varsayılan atanıyor, birleştiriliyor, API'de geri veriliyor, yok sayılıyordu.

### Neden `*bool`

`VaryByQuery` düz bir `bool` ve varsayılanı yok, yani sıfır değeri `false`. Ama tarif ettiği davranış her zaman `true` olmuştu.

**Sıfır değerini harfiyen uygulamak, ayarı hiç yazmamış her kurulumda `/search?q=cats` ile `/search?q=dogs`'u aynı önbellek girdisine düşürürdü** — bir ziyaretçinin arama sonuçlarını başkasına servis etmek. Sıkıştırmada (#66) kurulan desenin aynısı: yokluk artık "varyasyona devam et" demek; yalnızca açık `vary_by_query: false` çöktürüyor.

| yapılandırma | davranış |
|---|---|
| yazılmamış | sorgu anahtarda (bugünkü davranış) |
| `vary_by_query: true` | sorgu anahtarda |
| `vary_by_query: false` | sorgu anahtardan çıkar |

### Uygulama

`GenerateKeyWithoutQuery` çökmüş durumun anahtar üreticisi. Motor ikisi arasında **tek bir yerde** seçim yapıyor, böylece saklama yolu ile arama yolu farklı anahtar kullanamıyor. Kapalıyken yollar hâlâ ayrı girdiler üretiyor.

### Keskinlik

`SetVaryByQuery` çağrısı kaldırılınca ve `QueryVaries` hep `true` dönünce:

```
--- FAIL: TestServerVaryByQueryDisabledCollapses
    vary_by_query: false motora ulaşmıyor — sorgular ayrı girdilerde kaldı
--- FAIL: TestQueryVaries
    QueryVaries() = true, want false
```

### Boşa geçen testler

Motor testleri ilk yazdığımda geçiyordu ama hiçbir şey kanıtlamıyordu: `Created` sıfır olan bir `CachedResponse`'un son kullanma tarihi 1. yılda kalıyor, girdi hiç döndürülmüyor, ve "ıskalama bekleniyordu" iddialarının hepsi boş önbellekte de başarılı oluyor. Testler artık **önce girdinin geri alınabildiğini** doğruluyor, sonra farklı bir isteğin ıskaladığını.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
