### PR TITLE
fix(location): locations[].request_timeout hiç okunmuyordu

### DIFF
--- a/internal/server/server_dispatch.go
+++ b/internal/server/server_dispatch.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -208,6 +210,25 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
+		// Per-path request timeout. locations[].request_timeout was dead
+		// configuration: defined, merged and echoed back by the API, and no
+		// runtime path read it.
+		//
+		// The deadline goes on the request context, so everything downstream
+		// inherits it — the location proxy below, PHP dispatch (which builds
+		// its FastCGI deadline from ctx.Request's context), and any handler
+		// that honours cancellation. The loop breaks after this iteration
+		// (first match wins, as in nginx), so exactly one location's timeout
+		// can ever apply.
+		if loc.RequestTimeout.Duration > 0 {
+			timedCtx, cancel := context.WithTimeout(r.Context(), loc.RequestTimeout.Duration)
+			// handleRequest returns when the request is done, so this releases
+			// the timer at the right moment.
+			defer cancel()
+			r = r.WithContext(timedCtx)
+			ctx.Request = r
+		}
+
 		// Apply headers + cache-control
 		for k, v := range loc.Headers {
 			ctx.Response.Header().Set(k, v)
@@ -339,8 +360,15 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 			proxyReq.Header.Set("X-Forwarded-Host", r.Host)
 			resp, err := locationProxyHTTPClient.Do(proxyReq)
 			if err != nil {
-				s.logger.Error("location proxy error", "match", loc.Match, "target", loc.ProxyPass, "error", err)
-				renderDomainError(ctx.Response, http.StatusBadGateway, domain)
+				// A request_timeout that fired is a gateway timeout, not a bad
+				// gateway: the upstream was reachable, UWAS gave up waiting.
+				status := http.StatusBadGateway
+				if isDeadline(err) {
+					status = http.StatusGatewayTimeout
+				}
+				s.logger.Error("location proxy error", "match", loc.Match, "target", loc.ProxyPass,
+					"status", status, "error", err)
+				renderDomainError(ctx.Response, status, domain)
 				return
 			}
 			defer resp.Body.Close()
@@ -925,4 +953,10 @@ func cacheTTLFor(ruleTTL, domainTTL, globalDefaultTTL int) time.Duration {
 		}
 	}
 	return 60 * time.Second
+}
+
+// isDeadline reports whether an error is a context deadline, which for a
+// location proxy means request_timeout fired rather than the upstream failing.
+func isDeadline(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded)
 }

--- a/internal/server/server_location_timeout_test.go
+++ b/internal/server/server_location_timeout_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/uwaserver/uwas/internal/config"
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// locations[].request_timeout was dead configuration: defined, merged and
+// echoed back by the API, and no runtime path read it. A path configured to
+// give up after 100ms waited as long as the upstream took.
+
+func timeoutFixture(t *testing.T, locs []config.LocationConfig) http.Handler {
+	t.Helper()
+
+	cfg := &config.Config{
+		Global: config.GlobalConfig{WorkerCount: "1", LogLevel: "error", LogFormat: "text"},
+		Domains: []config.Domain{{
+			Host:      "loc.test",
+			Type:      "static",
+			Root:      t.TempDir(),
+			SSL:       config.SSLConfig{Mode: "off"},
+			Locations: locs,
+		}},
+	}
+	s := New(cfg, logger.New("error", "text"))
+	t.Cleanup(func() { s.cancel() })
+	return s.buildMiddlewareChain()
+}
+
+// yavasUpstream blocks until the request context is cancelled or delay passes.
+func yavasUpstream(t *testing.T, delay time.Duration) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(delay):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("geç yanıt"))
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func locIstek(h http.Handler, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = "loc.test"
+	req.Header.Set("User-Agent", "uwas-test")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// The timeout must fire, and be reported as a gateway timeout rather than a
+// bad gateway: the upstream was reachable, UWAS gave up waiting.
+func TestLocationRequestTimeoutFires(t *testing.T) {
+	up := yavasUpstream(t, 10*time.Second)
+	h := timeoutFixture(t, []config.LocationConfig{{
+		Match:          "/slow/",
+		ProxyPass:      up.URL,
+		RequestTimeout: config.Duration{Duration: 150 * time.Millisecond},
+	}})
+
+	start := time.Now()
+	rec := locIstek(h, "/slow/x")
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Errorf("durum = %d, want 504 — request_timeout uygulanmıyor", rec.Code)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("istek %v sürdü — 150ms zaman aşımı beklenmiyordu", elapsed)
+	}
+}
+
+// A path that responds inside the budget must be served normally.
+func TestLocationRequestTimeoutAllowsFastResponse(t *testing.T) {
+	up := yavasUpstream(t, 10*time.Millisecond)
+	h := timeoutFixture(t, []config.LocationConfig{{
+		Match:          "/fast/",
+		ProxyPass:      up.URL,
+		RequestTimeout: config.Duration{Duration: 5 * time.Second},
+	}})
+
+	rec := locIstek(h, "/fast/x")
+	if rec.Code != http.StatusOK {
+		t.Errorf("durum = %d, want 200", rec.Code)
+	}
+	if body := rec.Body.String(); body != "geç yanıt" {
+		t.Errorf("gövde = %q", body)
+	}
+}
+
+// No timeout configured must not impose one.
+func TestLocationWithoutTimeoutIsUnbounded(t *testing.T) {
+	up := yavasUpstream(t, 200*time.Millisecond)
+	h := timeoutFixture(t, []config.LocationConfig{{Match: "/x/", ProxyPass: up.URL}})
+
+	if rec := locIstek(h, "/x/y"); rec.Code != http.StatusOK {
+		t.Errorf("durum = %d, want 200 — zaman aşımı yokken kesildi", rec.Code)
+	}
+}
+
+// The location loop breaks on its first match (as in nginx), so a later,
+// longer timeout on an overlapping path must not apply.
+func TestLocationFirstMatchTimeoutWins(t *testing.T) {
+	up := yavasUpstream(t, 10*time.Second)
+	h := timeoutFixture(t, []config.LocationConfig{
+		{Match: "/a/", ProxyPass: up.URL, RequestTimeout: config.Duration{Duration: 150 * time.Millisecond}},
+		{Match: "/a/b", ProxyPass: up.URL, RequestTimeout: config.Duration{Duration: 30 * time.Second}},
+	})
+
+	start := time.Now()
+	rec := locIstek(h, "/a/b")
+	elapsed := time.Since(start)
+
+	if elapsed > 3*time.Second {
+		t.Errorf("istek %v sürdü — sonraki konumun 30sn'si uygulandı", elapsed)
+	}
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Errorf("durum = %d, want 504", rec.Code)
+	}
+}
+
+func TestContextDeadlineMapsToGatewayTimeout(t *testing.T) {
+	// Guards the errors.Is branch directly.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+	if !isDeadline(ctx.Err()) {
+		t.Error("DeadlineExceeded tanınmadı")
+	}
+}


### PR DESCRIPTION
Tanımlı, birleştiriliyor, admin API'de geri veriliyor — ve hiçbir yer okumuyordu. 100 ms sonra pes etmek üzere yapılandırılmış bir yol, upstream ne kadar sürerse o kadar bekliyordu.

### Uygulama

Son tarih **istek bağlamına** konuyor, böylece aşağıdaki her şey miras alıyor: konum proxy'si, PHP dispatch (FastCGI son tarihini `ctx.Request`'in bağlamından kuruyor), ve iptali onurlandıran her handler.

Konum döngüsü zaten ilk eşleşmede `break` ediyor (nginx gibi), yani **tam olarak bir** konumun zaman aşımı uygulanabilir.

> İlk sürümümde, sonraki bir konumun zaman aşımını uzatmasını engellemek için gereksiz bir bayrak eklemiştim — döngünün sonundaki `break`'i okumadan önce. Yanlış öncülle yazdığım test bunu ortaya çıkardı; bayrağı kaldırdım, testi de gerçekte doğru olanı doğrulayacak şekilde yeniden yazdım.

### 504, 502 değil

Konum proxy'sinde tetiklenen bir son tarih artık **504 Gateway Timeout** dönüyor. Upstream erişilebilirdi ve UWAS beklemekten vazgeçti; logu okuyan biri için bu farklı bir arıza.

### Keskinlik

Zaman aşımı uygulanmayınca:

```
--- FAIL: TestLocationRequestTimeoutFires (10.01s)
    durum = 200, want 504 — request_timeout uygulanmıyor
    istek 10.006708375s sürdü — 150ms zaman aşımı beklenmiyordu
```

Ayrıca kapsanıyor: bütçe içinde yanıtlayan yolun normal servis edilmesi, zaman aşımı ayarlanmamış konumun sınırsız kalması, ve çakışan yollarda ilk eşleşmenin kazanması.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
