### PR TITLE
fix(deploy): GIT_ASKPASS=/bin/true macOS ve minimal imajlarda mevcut değil

### DIFF
--- a/internal/admin/deploy/git.go
+++ b/internal/admin/deploy/git.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/uwaserver/uwas/internal/apps"
@@ -283,9 +284,33 @@ func resolveRemoteDefaultRef(ctx context.Context, workDir string) string {
 
 func defaultGitEnv() []string {
 	env := os.Environ()
-	env = append(env, "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true", "GIT_ALLOW_PROTOCOL=https:ssh:git")
+	env = append(env, "GIT_TERMINAL_PROMPT=0", "GIT_ALLOW_PROTOCOL=https:ssh:git")
+
+	// A no-op askpass keeps git from popping a GUI credential prompt when the
+	// environment has SSH_ASKPASS set; GIT_TERMINAL_PROMPT=0 only covers the
+	// terminal. The path was hardcoded to /bin/true, which does not exist on
+	// macOS (true lives in /usr/bin) or in some minimal images — and git
+	// answers a missing GIT_ASKPASS with "cannot run ...", which is worse
+	// than not setting it. Resolve it, or leave it out.
+	if p := noopBinary(); p != "" {
+		env = append(env, "GIT_ASKPASS="+p)
+	}
 	return env
 }
+
+// noopBinary locates a binary that exits successfully and prints nothing.
+// Resolved once: it cannot change while the process runs.
+var noopBinary = sync.OnceValue(func() string {
+	if p, err := exec.LookPath("true"); err == nil {
+		return p
+	}
+	for _, p := range []string{"/usr/bin/true", "/bin/true"} {
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p
+		}
+	}
+	return ""
+})
 
 func gitAuthEnv(gitURL, sshKeyPath, gitToken string) ([]string, string, func(), error) {
 	env := defaultGitEnv()
@@ -321,7 +346,11 @@ func gitAuthEnv(gitURL, sshKeyPath, gitToken string) ([]string, string, func(), 
 			return nil, "", cleanup, err
 		}
 		cleanup = func() { _ = os.Remove(path) }
-		env = append(env, "GIT_ASKPASS="+path)
+		// Replace, not append: a second GIT_ASKPASS= entry leaves the no-op
+		// helper in the environment behind the real one. exec resolves
+		// duplicates last-wins so it worked, but anything reading the slice
+		// sees a stale entry pointing at a binary that answers nothing.
+		env = setEnv(env, "GIT_ASKPASS", path)
 	}
 	return env, cloneURL, cleanup, nil
 }
@@ -794,4 +823,16 @@ func generateDeployKeyImpl(storeDir, appName string) (string, string, error) {
 		return "", "", fmt.Errorf("install deploy private key: %w", err)
 	}
 	return privatePath, string(ssh.MarshalAuthorizedKey(sshPub)), nil
+}
+
+// setEnv replaces KEY=... in an environment slice, appending if absent.
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
 }

--- a/internal/admin/deploy/git_askpass_test.go
+++ b/internal/admin/deploy/git_askpass_test.go
@@ -1,0 +1,122 @@
+package deploy
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// GIT_ASKPASS was hardcoded to /bin/true, which does not exist on macOS
+// (true lives in /usr/bin) or in some minimal images. git answers a missing
+// GIT_ASKPASS with "cannot run ...", so the guard against a GUI credential
+// prompt was itself an error on those hosts.
+
+func envValue(env []string, key string) (string, int) {
+	prefix := key + "="
+	value, count := "", 0
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			value = strings.TrimPrefix(kv, prefix)
+			count++
+		}
+	}
+	return value, count
+}
+
+// Whatever is set must exist and be executable, on every platform.
+func TestDefaultGitEnvAskpassExists(t *testing.T) {
+	path, count := envValue(defaultGitEnv(), "GIT_ASKPASS")
+	if count > 1 {
+		t.Errorf("GIT_ASKPASS %d kez ayarlandı", count)
+	}
+	if path == "" {
+		t.Skip("bu hostta no-op ikili bulunamadı; GIT_ASKPASS bilinçli olarak atlandı")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("GIT_ASKPASS=%s mevcut değil: %v — git \"cannot run\" hatası verir", path, err)
+	}
+	if info.IsDir() {
+		t.Fatalf("GIT_ASKPASS=%s bir dizin", path)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("GIT_ASKPASS=%s çalıştırılabilir değil (mod %v)", path, info.Mode())
+	}
+}
+
+func TestDefaultGitEnvBlocksPrompting(t *testing.T) {
+	env := defaultGitEnv()
+	if v, _ := envValue(env, "GIT_TERMINAL_PROMPT"); v != "0" {
+		t.Errorf("GIT_TERMINAL_PROMPT = %q, want 0", v)
+	}
+	if v, _ := envValue(env, "GIT_ALLOW_PROTOCOL"); v != "https:ssh:git" {
+		t.Errorf("GIT_ALLOW_PROTOCOL = %q", v)
+	}
+}
+
+// With a token, the real helper must be the only GIT_ASKPASS in the slice:
+// a leftover no-op entry points at a binary that answers nothing.
+func TestGitAuthEnvReplacesAskpass(t *testing.T) {
+	env, url, cleanup, err := gitAuthEnv("https://github.com/user/repo.git", "", "ghp_test123")
+	if err != nil {
+		t.Fatalf("gitAuthEnv: %v", err)
+	}
+	defer cleanup()
+
+	if url != "https://github.com/user/repo.git" {
+		t.Errorf("clone URL = %q", url)
+	}
+
+	path, count := envValue(env, "GIT_ASKPASS")
+	if count != 1 {
+		t.Errorf("GIT_ASKPASS %d kez var, 1 bekleniyordu — no-op yardımcı ortamda kaldı", count)
+	}
+	if path == "" {
+		t.Fatal("token varken GIT_ASKPASS ayarlanmadı")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("askpass yardımcısı mevcut değil: %v", err)
+	}
+	if !strings.Contains(path, "uwas-git-askpass") {
+		t.Errorf("GIT_ASKPASS=%s token yardımcısına işaret etmiyor", path)
+	}
+
+	cleanup()
+	if _, err := os.Stat(path); err == nil {
+		t.Error("cleanup askpass yardımcısını silmedi — token diskte kaldı")
+	}
+}
+
+// Without a token the no-op helper stays in place.
+func TestGitAuthEnvWithoutTokenKeepsNoop(t *testing.T) {
+	env, _, cleanup, err := gitAuthEnv("https://github.com/user/repo.git", "", "")
+	if err != nil {
+		t.Fatalf("gitAuthEnv: %v", err)
+	}
+	defer cleanup()
+
+	path, count := envValue(env, "GIT_ASKPASS")
+	if count > 1 {
+		t.Errorf("GIT_ASKPASS %d kez var", count)
+	}
+	if path != "" && strings.Contains(path, "uwas-git-askpass") {
+		t.Error("token yokken token yardımcısı ayarlandı")
+	}
+}
+
+func TestSetEnvReplacesAndAppends(t *testing.T) {
+	env := []string{"A=1", "GIT_ASKPASS=/eski", "B=2"}
+	env = setEnv(env, "GIT_ASKPASS", "/yeni")
+	if v, count := envValue(env, "GIT_ASKPASS"); v != "/yeni" || count != 1 {
+		t.Errorf("değiştirme başarısız: %q x%d", v, count)
+	}
+	if len(env) != 3 {
+		t.Errorf("uzunluk = %d, want 3", len(env))
+	}
+
+	env = setEnv([]string{"A=1"}, "YOK", "x")
+	if v, _ := envValue(env, "YOK"); v != "x" {
+		t.Errorf("ekleme başarısız: %q", v)
+	}
+}


### PR DESCRIPTION
`GIT_ASKPASS` `/bin/true`'ya sabitlenmişti. Bu dosya **macOS'ta yok** (`true` `/usr/bin`'de) ve bazı minimal imajlarda da bulunmuyor. git, bulunamayan bir `GIT_ASKPASS`'a `cannot run <yol>` diye cevap veriyor — yani GUI kimlik istemine karşı konan koruma, o hostlarda bizzat hata üretiyordu.

Amaç gerçek: `GIT_TERMINAL_PROMPT=0` yalnızca terminali kapsıyor, ortamdaki `SSH_ASKPASS` hâlâ bir GUI istemi açabilir. Bu yüzden ikili artık `PATH` üzerinden, `/usr/bin/true` ve `/bin/true` yedekleriyle, süreç başına bir kez çözümleniyor. Hiçbiri bulunamazsa **değişken hiç ayarlanmıyor**: git'in çalıştıramayacağı bir `GIT_ASKPASS`'tansa hiç olmaması iyidir.

### İkinci `GIT_ASKPASS`

`gitAuthEnv` token yardımcısı için ikinci bir `GIT_ASKPASS=` **ekliyordu**, ilkini değiştirmek yerine. `exec` yinelenenleri son-kazanır olarak çözdüğü için deploy çalışıyordu, ama dilim hiçbir şey cevaplamayan bir ikiliye işaret eden bayat bir girdi taşıyordu ve ortamı okuyan her şey onu görüyordu. Artık değiştiriliyor.

### Yan etki

Bu, `internal/admin`'deki `TestGitAuthEnv_WithToken`'ı da düzeltiyor. O test her `GIT_ASKPASS` girdisini gezip `stat` ediyordu; macOS'ta **kalıntı `/bin/true` yüzünden** düşüyordu, kontrol etmek için yazıldığı yardımcı yüzünden değil.

### Keskinlik

`/bin/true`'ya geri dönülünce:

```
--- FAIL: TestDefaultGitEnvAskpassExists
    GIT_ASKPASS=/bin/true mevcut değil: stat /bin/true: no such file or directory
    — git "cannot run" hatası verir
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
