### PR TITLE
fix(cloudflare): runner yokken tünel "başlatıldı" diyordu

### DIFF
--- a/internal/admin/handlers_cloudflare.go
+++ b/internal/admin/handlers_cloudflare.go
@@ -78,7 +78,10 @@ func (d *cfDeps) TunnelStatusOf(id string) (bool, int, string) {
 
 func (d *cfDeps) TunnelStart(id, token string) error {
 	if d.s.cfRunner == nil {
-		return nil
+		// Returning nil made the handler answer {"status":"started"} and write
+		// an audit entry saying the tunnel started, with no runner to start
+		// it. TunnelStop below has always reported this correctly.
+		return fmt.Errorf("tunnel runner not initialized")
 	}
 	return d.s.cfRunner.Start(id, token)
 }

--- a/internal/admin/handlers_cloudflare_coverage_test.go
+++ b/internal/admin/handlers_cloudflare_coverage_test.go
@@ -338,14 +338,23 @@ func TestHandleCloudflareTunnelStart_ConnectedNoRunner(t *testing.T) {
 	}()
 
 	s := testServer()
-	// testServer() has cfRunner == nil
+	// New() always builds a runner, so the comment this test used to carry —
+	// "testServer() has cfRunner == nil" — had stopped being true. With a
+	// runner in place the handler reached Runner.Start, which shells out to
+	// cloudflared: the test passed on a host without the binary (spawn fails
+	// → 500) and, on a host that has it, spawned a real cloudflared process
+	// with the fixture's fake token and got 200.
+	s.cfRunner = nil
+
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/cloudflare/tunnels/existing-id/start", nil)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500, body=%s", rec.Code, rec.Body.String())
 	}
-	t.Logf("start no runner body: %s", rec.Body.String())
+	if body := rec.Body.String(); strings.Contains(body, `"status":"started"`) {
+		t.Errorf("runner yokken başlatıldı bildirildi: %s", body)
+	}
 }
 
 func TestHandleCloudflareTunnelStart_ConnectedEmptyToken(t *testing.T) {


### PR DESCRIPTION
`cfDeps.TunnelStart`, `cfRunner` nil iken `nil` dönüyordu. Handler `{"status":"started"}` cevaplıyor ve denetim kaydına tünelin başladığını yazıyordu — başlatacak hiçbir şey yokken. Üç satır aşağıdaki `TunnelStop` bunu her zaman doğru bildirmiş.

### Testin çürümesi

Bunu kapsaması gereken test `// testServer() has cfRunner == nil` yorumunu taşıyordu. `New()` koşulsuz olarak runner kurmaya başladığında bu doğru olmaktan çıktı.

Runner mevcutken handler `Runner.Start`'a ulaşıyor, o da `cloudflared`'a shell out ediyor. Yani test **adını koymadığı bir sebeple** geçiyordu: ikilinin olmadığı bir hostta `spawn` başarısız oluyor ve handler 500 dönüyor.

İkilinin **olduğu** bir hostta ise düşüyor — ve zararsızca değil: `go test` sırasında fixture'ın sahte connector token'ıyla **gerçek bir cloudflared süreci başlatıyor**. Bunu ortaya çıkaran da bu oldu; paket, cloudflared kurulu bir geliştirici makinesinde düşüyor, CI'da geçiyor.

### Düzeltme

Test artık `cfRunner`'ı gerçekten temizliyor — adının iddia ettiği şey — ve gövdenin başarı bildirmediğini de doğruluyor.

**İki yarı da gerekli:** nil koruması olmadan `{"status":"started"}` alıyor; runner temizlenmeden ise hostta ne kurulu olduğuna bağlı kalıyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
