### PR TITLE
test(wordpress): yinelenen kurulum testi #57'den sonra da kararsızdı

### DIFF
--- a/internal/admin/admin_coverage2_test.go
+++ b/internal/admin/admin_coverage2_test.go
@@ -4319,32 +4319,12 @@ func TestWPInstallWithDomain(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 }
 
-func TestWPInstallDuplicateRunning(t *testing.T) {
-	// The handler answers 409 while an install is in flight. That state lives on
-	// the package-level wpHandler, so this test used to depend on some earlier
-	// test having left an install running — order- and timing-dependent, and it
-	// failed under -race when the earlier goroutine had already finished.
-	//
-	// The precondition is now set up here: the first request marks an install
-	// running, the second is the duplicate under test.
-	s := testServer()
-	root := t.TempDir()
-	body := func() *strings.Reader {
-		return strings.NewReader(`{"domain":"test.com","web_root":"` + filepath.ToSlash(root) + `"}`)
-	}
-
-	first := httptest.NewRecorder()
-	s.handleWPInstall(first, httptest.NewRequest("POST", "/api/v1/wordpress/install", body()))
-	if first.Code != 200 {
-		t.Fatalf("first install: status = %d, want 200, body: %s", first.Code, first.Body.String())
-	}
-
-	second := httptest.NewRecorder()
-	s.handleWPInstall(second, httptest.NewRequest("POST", "/api/v1/wordpress/install", body()))
-	if second.Code != 409 {
-		t.Errorf("duplicate install: status = %d, want 409, body: %s", second.Code, second.Body.String())
-	}
-}
+// TestWPInstallDuplicateRunning moved to internal/admin/wordpress, where the
+// installer can be held open. Here it raced the real wp.Install: the handler
+// writes the finished result over its "running" state, so an install that
+// failed fast cleared the precondition before the duplicate request arrived
+// and the second call got 200 instead of 409. It failed about one run in
+// twelve on this machine.
 
 // =============================================================================
 // Additional coverage: handleClone with root

--- a/internal/admin/wordpress/handler.go
+++ b/internal/admin/wordpress/handler.go
@@ -31,6 +31,12 @@ type Deps interface {
 	RecordAudit(r *http.Request, action, detail string, success bool)
 }
 
+// installFn runs the install. It exists so a test can hold an install
+// in flight: the duplicate-install response depends on h.result still saying
+// "running", and racing a real wp.Install to observe that is only reliable
+// when the install is slow.
+var installFn = wp.Install
+
 // Handler holds WordPress admin API handlers.
 type Handler struct {
 	deps   Deps
@@ -104,7 +110,7 @@ func (h *Handler) Install(w http.ResponseWriter, r *http.Request) {
 	h.deps.LogInfo("starting WordPress install", "domain", req.Domain)
 
 	go func() {
-		result := wp.Install(req)
+		result := installFn(req)
 		h.mu.Lock()
 		h.result = &result
 		h.mu.Unlock()

--- a/internal/admin/wordpress/handler_duplicate_install_test.go
+++ b/internal/admin/wordpress/handler_duplicate_install_test.go
@@ -1,0 +1,144 @@
+package wordpress
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	wp "github.com/uwaserver/uwas/internal/wordpress"
+)
+
+// The handler answers 409 while an install is in flight. Observing that by
+// racing a real wp.Install is only reliable when the install is slow: it
+// writes the finished result over h.result, so an install that fails fast —
+// no network, no PHP, an unwritable root — clears the "running" state before
+// the duplicate request arrives, and the second call gets 200.
+//
+// installFn is held open here instead, so the in-flight window is the test's
+// to control.
+
+type sahteDeps struct{ kok string }
+
+func (d sahteDeps) RequireDomainAccess(http.ResponseWriter, *http.Request, string, string) bool {
+	return true
+}
+func (d sahteDeps) CanAccessDomain(*http.Request, string) bool { return true }
+func (d sahteDeps) AuthorizedDomainRoot(_ http.ResponseWriter, _ *http.Request, _, _ string) (string, bool) {
+	return d.kok, true
+}
+func (d sahteDeps) DomainRoot(string) string                        { return d.kok }
+func (d sahteDeps) GlobalWebRoot() string                           { return d.kok }
+func (d sahteDeps) Domains() []wp.DomainInfo                        { return nil }
+func (d sahteDeps) LogInfo(string, ...any)                          {}
+func (d sahteDeps) RecordAudit(*http.Request, string, string, bool) {}
+
+func TestInstallRejectsDuplicateWhileRunning(t *testing.T) {
+	kok := t.TempDir()
+
+	// Hold the install open for the duration of the test.
+	birak := make(chan struct{})
+	bitti := make(chan struct{})
+	orig := installFn
+	installFn = func(req wp.InstallRequest) wp.InstallResult {
+		<-birak
+		close(bitti)
+		return wp.InstallResult{Status: "failed", Domain: req.Domain}
+	}
+	t.Cleanup(func() {
+		close(birak)
+		select {
+		case <-bitti:
+		case <-time.After(5 * time.Second):
+			t.Error("kurulum goroutine'i bitmedi")
+		}
+		installFn = orig
+	})
+
+	h := New(sahteDeps{kok: kok})
+	govde := func() *strings.Reader {
+		return strings.NewReader(`{"domain":"test.com","web_root":"` + strings.ReplaceAll(kok, `\`, `\\`) + `"}`)
+	}
+
+	first := httptest.NewRecorder()
+	h.Install(first, httptest.NewRequest(http.MethodPost, "/api/v1/wordpress/install", govde()))
+	if first.Code != http.StatusOK {
+		t.Fatalf("ilk kurulum: durum %d, gövde %s", first.Code, first.Body.String())
+	}
+
+	second := httptest.NewRecorder()
+	h.Install(second, httptest.NewRequest(http.MethodPost, "/api/v1/wordpress/install", govde()))
+	if second.Code != http.StatusConflict {
+		t.Errorf("yinelenen kurulum: durum %d, want 409, gövde %s", second.Code, second.Body.String())
+	}
+	if body := second.Body.String(); !strings.Contains(body, "already in progress") {
+		t.Errorf("gövde = %s", body)
+	}
+}
+
+// Once the install finishes, a new one must be accepted.
+func TestInstallAcceptedAfterPreviousFinishes(t *testing.T) {
+	kok := t.TempDir()
+
+	// Every invocation signals here. Waiting on it keeps the goroutine from
+	// outliving the test — t.TempDir()'s cleanup runs while it is still
+	// writing otherwise, and fails with "directory not empty".
+	cagrildi := make(chan struct{}, 4)
+	orig := installFn
+	installFn = func(req wp.InstallRequest) wp.InstallResult {
+		defer func() { cagrildi <- struct{}{} }()
+		return wp.InstallResult{Status: "failed", Domain: req.Domain}
+	}
+	t.Cleanup(func() { installFn = orig })
+
+	bekle := func(ne string) {
+		t.Helper()
+		select {
+		case <-cagrildi:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s kurulum goroutine'i bitmedi", ne)
+		}
+	}
+
+	h := New(sahteDeps{kok: kok})
+	govde := func() *strings.Reader {
+		return strings.NewReader(`{"domain":"test.com","web_root":"` + strings.ReplaceAll(kok, `\`, `\\`) + `"}`)
+	}
+
+	first := httptest.NewRecorder()
+	h.Install(first, httptest.NewRequest(http.MethodPost, "/api/v1/wordpress/install", govde()))
+	if first.Code != http.StatusOK {
+		t.Fatalf("ilk kurulum: durum %d", first.Code)
+	}
+	bekle("ilk")
+	// The signal fires as installFn returns; the handler's goroutine writes
+	// h.result after that, so waiting on the channel alone leaves a window
+	// where the next request still sees "running".
+	durumTemizlenene(t, h)
+
+	second := httptest.NewRecorder()
+	h.Install(second, httptest.NewRequest(http.MethodPost, "/api/v1/wordpress/install", govde()))
+	if second.Code != http.StatusOK {
+		t.Errorf("biten kurulumdan sonra durum %d, want 200, gövde %s", second.Code, second.Body.String())
+	}
+	bekle("ikinci")
+}
+
+// durumTemizlenene waits until the handler no longer reports an install in
+// flight.
+func durumTemizlenene(t *testing.T, h *Handler) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mu.Lock()
+		calisiyor := h.result != nil && h.result.Status == "running"
+		h.mu.Unlock()
+		if !calisiyor {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("kurulum durumu \"running\" olarak takılı kaldı")
+}


### PR DESCRIPTION
`TestWPInstallDuplicateRunning`, #57'den sonra hâlâ **on iki koşunun yaklaşık birinde** düşüyordu. O PR önkoşulu testin içine taşımıştı ama yarışı yerinde bırakmış.

### Yarış

Handler `h.result`'ı `"running"` işaretliyor, kurulumu bir goroutine'de başlatıyor, ve o goroutine biten sonucu **üzerine yazıyor**.

409'u gerçek bir `wp.Install`'la yarışarak gözlemlemek yalnızca kurulum yavaşken işe yarıyor. Hızlı başarısız olan biri — ağ yok, PHP yok, yazılamayan kök — yinelenen istek gelmeden durumu temizliyor ve ikinci çağrı 200 alıyor.

### Düzeltme

Kurucu artık üzerine yazılabilir bir paket değişkeni ve test onu bir kanalla açık tutuyor. Uçuş penceresi umut edilen bir şey değil, testin kontrolünde.

Test `internal/admin/wordpress`'e taşındı — o durumun ve sınanan davranışın yaşadığı yer. `internal/admin`'deki kopya, nereye ve neden gittiğini söyleyen bir notla değiştirildi.

### Yol boyunca iki hatam

İkisini de yazıyorum çünkü ilk sürümde ikisi de vardı:

**Yerine koyduğum test kendisi kararsızdı**, 30 koşunun 3'ünde — `TempDir RemoveAll cleanup: directory not empty`. İkinci kurulumun goroutine'i testten uzun yaşıyordu. Stub artık her çağrıyı sinyalliyor ve test onu bekliyor.

**O sinyali beklemek de yetmiyor:** sinyal `installFn` dönerken atılıyor, handler `h.result`'ı ondan sonra yazıyor, yani sonraki istek hâlâ `"running"` görebilir. Test durumun temizlenmesini de bekliyor.

40 koşuda 0 hata, `-race` altında temiz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
