### PR TITLE
fix(server): type=app ve app: bloğu sessizce hiçbir şey yapmıyordu

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -602,6 +602,26 @@ func New(cfg *config.Config, log *logger.Logger) *Server {
 		}
 	}
 
+	// type=app is deprecated: dispatchHandler answers it with a 502 naming
+	// the replacement. Validation still accepts it — removing it would stop
+	// an existing config from loading — so without this the operator only
+	// finds out when traffic arrives. The app: block goes with it: nothing
+	// starts a process from a domain's own app config, and merge.go copying
+	// the fields around is not the same as using them.
+	for _, d := range cfg.Domains {
+		if d.Type == string(config.DomainTypeApp) {
+			s.logger.Warn("domain type=app is no longer supported and will answer 502; "+
+				"create an app under /api/v1/apps and route this domain with type=proxy and an apps://<name> upstream",
+				"domain", d.Host)
+			continue
+		}
+		if d.App.Command != "" || d.App.Runtime != "" || d.App.WorkDir != "" {
+			s.logger.Warn("domain app: block is ignored — no process is started from it; "+
+				"use /api/v1/apps and an apps://<name> upstream instead",
+				"domain", d.Host)
+		}
+	}
+
 	// Per-domain rate limiters
 	s.domainRateLimiters = make(map[string]*middleware.RateLimiter)
 	for _, d := range cfg.Domains {

--- a/internal/server/server_deprecated_app_test.go
+++ b/internal/server/server_deprecated_app_test.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/config"
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// type=app is deprecated: dispatchHandler answers it with a 502 naming the
+// replacement. Validation still accepts it — removing it would stop an
+// existing config from loading — so without a startup warning the operator
+// only finds out when traffic arrives.
+//
+// The app: block goes with it. Nothing starts a process from a domain's own
+// app config; merge.go copies the fields around, which is not the same as
+// using them.
+
+func acilisLoglari(t *testing.T, domains []config.Domain) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	// logger.New captures the writer at construction.
+	log := logger.New("warn", "text")
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	cfg := &config.Config{
+		Global:  config.GlobalConfig{WorkerCount: "1", LogLevel: "warn", LogFormat: "text"},
+		Domains: domains,
+	}
+	s := New(cfg, log)
+	s.cancel()
+
+	os.Stdout = orig
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+func TestDeprecatedAppTypeWarnsAtStartup(t *testing.T) {
+	out := acilisLoglari(t, []config.Domain{{
+		Host: "app.test",
+		Type: "app",
+		SSL:  config.SSLConfig{Mode: "off"},
+	}})
+
+	if !strings.Contains(out, "no longer supported") {
+		t.Errorf("type=app uyarı üretmedi — operatör ancak trafik gelince öğrenir:\n%s", out)
+	}
+	if !strings.Contains(out, "apps://") {
+		t.Errorf("uyarı yerine ne kullanılacağını söylemiyor:\n%s", out)
+	}
+	if !strings.Contains(out, "app.test") {
+		t.Errorf("uyarı hangi domain olduğunu söylemiyor:\n%s", out)
+	}
+}
+
+// A leftover app: block on a supported type must be reported too: it looks
+// like configuration and does nothing.
+func TestIgnoredAppBlockWarns(t *testing.T) {
+	out := acilisLoglari(t, []config.Domain{{
+		Host: "proxy.test",
+		Type: "proxy",
+		SSL:  config.SSLConfig{Mode: "off"},
+		App:  config.AppConfig{Command: "npm start", Runtime: "node"},
+		Proxy: config.ProxyConfig{
+			Upstreams: []config.Upstream{{Address: "http://127.0.0.1:3000", Weight: 1}},
+		},
+	}})
+
+	if !strings.Contains(out, "app: block is ignored") {
+		t.Errorf("kullanılmayan app bloğu için uyarı yok:\n%s", out)
+	}
+}
+
+// A domain that mentions neither must stay quiet.
+func TestNoAppConfigNoWarning(t *testing.T) {
+	out := acilisLoglari(t, []config.Domain{{
+		Host: "plain.test",
+		Type: "static",
+		Root: t.TempDir(),
+		SSL:  config.SSLConfig{Mode: "off"},
+	}})
+
+	if strings.Contains(out, "app:") || strings.Contains(out, "no longer supported") {
+		t.Errorf("app yapılandırması olmayan domain için uyarı verildi:\n%s", out)
+	}
+}


### PR DESCRIPTION
`dispatchHandler` `type=app`'i zaten net bir 502 ile karşılıyor ve yerine ne kullanılacağını söylüyor — yani kullanımdan kaldırma **bilinçli ve iyi işaretlenmiş**, ama yalnızca istek anında.

Doğrulama tipi hâlâ kabul ediyor (kaldırmak mevcut bir config'in yüklenmesini durdururdu), dolayısıyla o şekilde yapılandırılmış bir domain sessizce açılıyor ve operatör **ancak trafik gelince** öğreniyor.

### `app:` bloğu da onunla birlikte

Ondan hiçbir süreç başlatılmıyor:

| alan | çalışma anında |
|---|---|
| `command`, `work_dir`, `runtime`, `auto_restart`, `disabled` | yalnızca `merge.go` — config'ler arasında kopyalıyor |
| `port` | yalnızca port çakışması tespiti |
| `env` | yalnızca gizleme için **temizleniyor** |

Yani blok yapılandırma gibi görünüyor ve hiçbir şey yapmıyor.

İkisi de artık açılışta bildiriliyor, 502'nin işaret ettiği aynı çözümü göstererek. **Reddedilmiyor, uyarılıyor** — tipin yüklenmeye devam etmesi gerekiyor.

### Nasıl neredeyse kaçırdım

Kaydetmeye değer. Ölü ayar tarayıcım `AppConfig`'i hiç işaretlemedi, çünkü `.Command` arıyor ve ağacın başka yerindeki `exec.Command`'e takılıyor.

Sonra nitelikli bir yeniden kontrol **her alanın kullanıldığını** gösterir gibi oldu — çünkü `internal/config`'i hariç tutmuyordu, ve `merge.go` hepsini sayıyor.

**Birleştirilmek kullanılmak değil**, ve iki geçiş de bu ayrımı aramıyordu.

### Keskinlik

Uyarı kaldırılınca:

```
--- FAIL: TestDeprecatedAppTypeWarnsAtStartup
    type=app uyarı üretmedi — operatör ancak trafik gelince öğrenir
    uyarı yerine ne kullanılacağını söylemiyor
    uyarı hangi domain olduğunu söylemiyor
--- FAIL: TestIgnoredAppBlockWarns
    kullanılmayan app bloğu için uyarı yok
```

Ayrıca kapsanıyor: app yapılandırması olmayan domainin sessiz kalması.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
