### PR TITLE
fix(waf): security.waf.rules hiç okunmuyordu

### DIFF
--- a/internal/middleware/coverage_100_test.go
+++ b/internal/middleware/coverage_100_test.go
@@ -806,7 +806,7 @@ func TestEnqueueGeoLookupSkipsWhenInflight(t *testing.T) {
 func TestDomainWAFGuardURLBlockedExpectHeader(t *testing.T) {
 	log := logger.New("error", "text")
 	stats := NewSecurityStats()
-	guard := DomainWAFGuard(log, nil, stats)
+	guard := DomainWAFGuard(log, nil, nil, stats)
 	r := httptest.NewRequest(http.MethodGet, "http://x.test/?q=<script>alert(1)</script>", nil)
 	r.Header.Set("Expect", "100-continue")
 	rec := httptest.NewRecorder()
@@ -821,7 +821,7 @@ func TestDomainWAFGuardURLBlockedExpectHeader(t *testing.T) {
 func TestDomainWAFGuardBodyBlockedRestoresStream(t *testing.T) {
 	log := logger.New("error", "text")
 	stats := NewSecurityStats()
-	guard := DomainWAFGuard(log, nil, stats)
+	guard := DomainWAFGuard(log, nil, nil, stats)
 	r := httptest.NewRequest(http.MethodPost, "http://x.test/submit",
 		strings.NewReader("name=1' UNION SELECT password FROM users--"))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -836,7 +836,7 @@ func TestDomainWAFGuardBodyBlockedRestoresStream(t *testing.T) {
 
 func TestDomainWAFGuardSafeBodyPassesAndPreserved(t *testing.T) {
 	log := logger.New("error", "text")
-	guard := DomainWAFGuard(log, nil, nil)
+	guard := DomainWAFGuard(log, nil, nil, nil)
 	r := httptest.NewRequest(http.MethodPost, "http://x.test/submit",
 		strings.NewReader("name=alice&age=30"))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -852,7 +852,7 @@ func TestDomainWAFGuardSafeBodyPassesAndPreserved(t *testing.T) {
 
 func TestDomainWAFGuardBypassPath(t *testing.T) {
 	log := logger.New("error", "text")
-	guard := DomainWAFGuard(log, []string{"/health"}, nil)
+	guard := DomainWAFGuard(log, []string{"/health"}, nil, nil)
 	r := httptest.NewRequest(http.MethodGet, "http://x.test/health?q=<script>", nil)
 	if !guard(httptest.NewRecorder(), r) {
 		t.Fatal("bypass path should always proceed")

--- a/internal/middleware/guard_adapter_test.go
+++ b/internal/middleware/guard_adapter_test.go
@@ -11,7 +11,7 @@ func CORS(cfg CORSConfig) Middleware {
 }
 
 func DomainWAF(log *logger.Logger, bypassPaths []string, stats *SecurityStats) Middleware {
-	return middlewareFromGuard(DomainWAFGuard(log, bypassPaths, stats))
+	return middlewareFromGuard(DomainWAFGuard(log, bypassPaths, nil, stats))
 }
 
 func middlewareFromGuard(guard func(http.ResponseWriter, *http.Request) bool) Middleware {

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -24,26 +24,63 @@ var defaultBlockedPaths = []string{
 	".editorconfig", ".gitignore",
 }
 
+// WAF rule families. security.waf.rules names these; an empty list means all
+// of them, which is what the WAF has always done.
+const (
+	WAFSQLInjection   = "sql_injection"
+	WAFXSS            = "xss"
+	WAFPathTraversal  = "path_traversal"
+	WAFShellInjection = "shell_injection"
+	WAFPHP            = "php"
+)
+
+// wafFamilies lists every family in a stable order, for reporting.
+var wafFamilies = []string{
+	WAFSQLInjection, WAFXSS, WAFPathTraversal, WAFShellInjection, WAFPHP,
+}
+
+// WAFRuleNames returns every family name, for error messages.
+func WAFRuleNames() []string {
+	out := make([]string, len(wafFamilies))
+	copy(out, wafFamilies)
+	return out
+}
+
+// KnownWAFRule reports whether a configured rule names a family this WAF has.
+func KnownWAFRule(name string) bool {
+	for _, f := range wafFamilies {
+		if strings.EqualFold(strings.TrimSpace(name), f) {
+			return true
+		}
+	}
+	return false
+}
+
+type wafRule struct {
+	family string
+	re     *regexp.Regexp
+}
+
 // wafURLPatterns are checked against URL + query string only.
-var wafURLPatterns = []*regexp.Regexp{
+var wafURLPatterns = []wafRule{
 	// SQL injection
-	regexp.MustCompile(`(?i)(union\s+select|insert\s+into|delete\s+from|drop\s+table|alter\s+table)`),
-	regexp.MustCompile(`(?i)(--|;)\s+(drop|alter|delete|insert|update)`),
-	regexp.MustCompile(`(?i)(sleep\s*\(|benchmark\s*\(|load_file\s*\(|into\s+outfile)`),
+	{WAFSQLInjection, regexp.MustCompile(`(?i)(union\s+select|insert\s+into|delete\s+from|drop\s+table|alter\s+table)`)},
+	{WAFSQLInjection, regexp.MustCompile(`(?i)(--|;)\s+(drop|alter|delete|insert|update)`)},
+	{WAFSQLInjection, regexp.MustCompile(`(?i)(sleep\s*\(|benchmark\s*\(|load_file\s*\(|into\s+outfile)`)},
 	// XSS in URL
-	regexp.MustCompile(`(?i)<script[^>]*>`),
-	regexp.MustCompile(`(?i)(javascript|vbscript)\s*:`),
-	regexp.MustCompile(`(?i)on(error|load|click|mouseover)\s*=`),
+	{WAFXSS, regexp.MustCompile(`(?i)<script[^>]*>`)},
+	{WAFXSS, regexp.MustCompile(`(?i)(javascript|vbscript)\s*:`)},
+	{WAFXSS, regexp.MustCompile(`(?i)on(error|load|click|mouseover)\s*=`)},
 	// Path traversal
-	regexp.MustCompile(`\.\./`),
-	regexp.MustCompile(`\.\.\\`),
+	{WAFPathTraversal, regexp.MustCompile(`\.\./`)},
+	{WAFPathTraversal, regexp.MustCompile(`\.\.\\`)},
 	// Shell injection
-	regexp.MustCompile("(?i)(;|\\||`|\\$\\(|\\$\\{)\\s*(cat|ls|rm|wget|curl|nc|bash|sh|python|perl|ruby|php)"),
-	regexp.MustCompile(`(?i)/etc/(passwd|shadow|hosts)`),
-	regexp.MustCompile(`(?i)/proc/self/`),
+	{WAFShellInjection, regexp.MustCompile("(?i)(;|\\||`|\\$\\(|\\$\\{)\\s*(cat|ls|rm|wget|curl|nc|bash|sh|python|perl|ruby|php)")},
+	{WAFShellInjection, regexp.MustCompile(`(?i)/etc/(passwd|shadow|hosts)`)},
+	{WAFShellInjection, regexp.MustCompile(`(?i)/proc/self/`)},
 	// PHP specific
-	regexp.MustCompile(`(?i)(eval|assert|system|exec|passthru|shell_exec|popen)\s*\(`),
-	regexp.MustCompile(`(?i)php://(input|filter|data)`),
+	{WAFPHP, regexp.MustCompile(`(?i)(eval|assert|system|exec|passthru|shell_exec|popen)\s*\(`)},
+	{WAFPHP, regexp.MustCompile(`(?i)php://(input|filter|data)`)},
 }
 
 // wafBodyPatterns are checked against POST body only.
@@ -51,13 +88,39 @@ var wafURLPatterns = []*regexp.Regexp{
 //   - No <script> check; CMS editors and email templates submit HTML.
 //   - No sleep()/benchmark(); code playgrounds and JS snippets are legitimate.
 //   - Only patterns that are almost certainly attacks in form data.
-var wafBodyPatterns = []*regexp.Regexp{
+var wafBodyPatterns = []wafRule{
 	// XSS protocol execution is never legitimate in form data.
-	regexp.MustCompile(`(?i)(javascript|vbscript)\s*:\s*[a-z]`),
+	{WAFXSS, regexp.MustCompile(`(?i)(javascript|vbscript)\s*:\s*[a-z]`)},
 	// SQL injection multi-word patterns have very low false positive rate.
-	regexp.MustCompile(`(?i)(union\s+select|drop\s+table|alter\s+table)`),
+	{WAFSQLInjection, regexp.MustCompile(`(?i)(union\s+select|drop\s+table|alter\s+table)`)},
 	// PHP stream wrappers are never legitimate in form submissions.
-	regexp.MustCompile(`(?i)php://(input|filter|data)`),
+	{WAFPHP, regexp.MustCompile(`(?i)php://(input|filter|data)`)},
+}
+
+// wafFamilySet turns a configured rule list into a lookup. A nil result means
+// "every family", which is what an empty list has always meant in practice —
+// the list was never read, so every deployment has been getting all of them.
+func wafFamilySet(rules []string) map[string]bool {
+	if len(rules) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(rules))
+	for _, r := range rules {
+		r = strings.ToLower(strings.TrimSpace(r))
+		// Unrecognised names are dropped rather than kept: a set that names
+		// only families this WAF does not have matches nothing, and every
+		// request would pass. A typo in the rule list must not be a way to
+		// turn the WAF off.
+		if r != "" && KnownWAFRule(r) {
+			set[r] = true
+		}
+	}
+	if len(set) == 0 {
+		// Nothing usable was configured. Fall back to every family — the
+		// behaviour before the list was read — instead of enforcing none.
+		return nil
+	}
+	return set
 }
 
 // SecurityGuard blocks access to sensitive paths (global middleware).
@@ -92,7 +155,13 @@ func SecurityGuard(log *logger.Logger, blockedPaths []string, stats *SecuritySta
 
 // DomainWAFGuard returns a predicate closure for per-domain WAF checks.
 // It returns true when the request should proceed.
-func DomainWAFGuard(log *logger.Logger, bypassPaths []string, stats *SecurityStats) func(w http.ResponseWriter, r *http.Request) bool {
+// rules names the families to enforce; empty means all of them.
+//
+// security.waf.rules was dead configuration: documented as
+// `sql_injection | xss | path_traversal` and never read, so every WAF-enabled
+// domain got every family whatever it listed.
+func DomainWAFGuard(log *logger.Logger, bypassPaths []string, rules []string, stats *SecurityStats) func(w http.ResponseWriter, r *http.Request) bool {
+	families := wafFamilySet(rules)
 	return func(w http.ResponseWriter, r *http.Request) bool {
 		path := r.URL.Path
 		for _, prefix := range bypassPaths {
@@ -106,7 +175,7 @@ func DomainWAFGuard(log *logger.Logger, bypassPaths []string, stats *SecuritySta
 			fullURI += "?" + r.URL.RawQuery
 		}
 		decodedURI, _ := url.QueryUnescape(fullURI)
-		if matchWAFURL(fullURI, decodedURI) {
+		if matchWAF(wafURLPatterns, families, fullURI, decodedURI) {
 			if stats != nil {
 				stats.Record(r.RemoteAddr, path, "waf", r.UserAgent())
 			}
@@ -134,7 +203,7 @@ func DomainWAFGuard(log *logger.Logger, bypassPaths []string, stats *SecuritySta
 				r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(bodyBytes), r.Body))
 				body := string(bodyBytes)
 				decodedBody, _ := url.QueryUnescape(body)
-				if matchWAFBody(body, decodedBody) {
+				if matchWAF(wafBodyPatterns, families, body, decodedBody) {
 					if stats != nil {
 						stats.Record(r.RemoteAddr, path, "waf", r.UserAgent())
 					}
@@ -172,20 +241,24 @@ func isAPContentType(ct string) bool {
 	return strings.HasSuffix(ct, "+json") || strings.HasSuffix(ct, "+xml")
 }
 
-func matchWAFURL(raw, decoded string) bool {
-	for _, pattern := range wafURLPatterns {
-		if pattern.MatchString(raw) || (decoded != raw && pattern.MatchString(decoded)) {
+// matchWAF reports whether any enabled rule matches. families nil means every
+// family, which is what an empty security.waf.rules has always meant.
+func matchWAF(rules []wafRule, families map[string]bool, raw, decoded string) bool {
+	for _, r := range rules {
+		if families != nil && !families[r.family] {
+			continue
+		}
+		if r.re.MatchString(raw) || (decoded != raw && r.re.MatchString(decoded)) {
 			return true
 		}
 	}
 	return false
 }
 
+func matchWAFURL(raw, decoded string) bool {
+	return matchWAF(wafURLPatterns, nil, raw, decoded)
+}
+
 func matchWAFBody(raw, decoded string) bool {
-	for _, pattern := range wafBodyPatterns {
-		if pattern.MatchString(raw) || (decoded != raw && pattern.MatchString(decoded)) {
-			return true
-		}
-	}
-	return false
+	return matchWAF(wafBodyPatterns, nil, raw, decoded)
 }

--- a/internal/middleware/security_waf_rules_test.go
+++ b/internal/middleware/security_waf_rules_test.go
@@ -1,0 +1,134 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// security.waf.rules was dead configuration: SPECIFICATION.md documents
+// `sql_injection | xss | path_traversal` and nothing read it, so every
+// WAF-enabled domain got every family whatever it listed.
+
+// wafIstek runs one request through the guard and reports whether it passed.
+func wafIstek(t *testing.T, rules []string, target string) bool {
+	t.Helper()
+
+	guard := DomainWAFGuard(logger.New("error", "text"), nil, rules, nil)
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.RemoteAddr = "203.0.113.1:5000"
+	return guard(httptest.NewRecorder(), req)
+}
+
+const (
+	sqlSaldiri   = "/?q=union+select+password+from+users"
+	xssSaldiri   = "/?q=%3Cscript%3Ealert(1)%3C/script%3E"
+	yolSaldiri   = "/../../etc/shadow"
+	kabukSaldiri = "/?x=;cat+/etc/passwd"
+)
+
+// No list means every family, which is what has always happened.
+func TestWAFEmptyRulesEnforcesEverything(t *testing.T) {
+	for _, saldiri := range []string{sqlSaldiri, xssSaldiri, yolSaldiri, kabukSaldiri} {
+		if wafIstek(t, nil, saldiri) {
+			t.Errorf("kural listesi yokken %q geçti", saldiri)
+		}
+		if wafIstek(t, []string{}, saldiri) {
+			t.Errorf("boş kural listesiyle %q geçti", saldiri)
+		}
+	}
+}
+
+// A list selects: the named family blocks, the others no longer run.
+func TestWAFRulesSelectFamilies(t *testing.T) {
+	rules := []string{WAFSQLInjection}
+
+	if wafIstek(t, rules, sqlSaldiri) {
+		t.Error("sql_injection listelenmişken SQL saldırısı geçti")
+	}
+	if !wafIstek(t, rules, xssSaldiri) {
+		t.Error("yalnızca sql_injection listeliyken XSS de engellendi — rules seçim yapmıyor")
+	}
+	if !wafIstek(t, rules, yolSaldiri) {
+		t.Error("yalnızca sql_injection listeliyken yol geçişi de engellendi")
+	}
+}
+
+func TestWAFRulesMultipleFamilies(t *testing.T) {
+	rules := []string{WAFXSS, WAFPathTraversal}
+
+	if wafIstek(t, rules, xssSaldiri) {
+		t.Error("xss listelenmişken XSS geçti")
+	}
+	if wafIstek(t, rules, yolSaldiri) {
+		t.Error("path_traversal listelenmişken yol geçişi geçti")
+	}
+	if !wafIstek(t, rules, sqlSaldiri) {
+		t.Error("listelenmemiş sql_injection hâlâ uygulanıyor")
+	}
+}
+
+// Case and surrounding space must not change which families run.
+func TestWAFRulesNormalised(t *testing.T) {
+	if wafIstek(t, []string{" SQL_Injection "}, sqlSaldiri) {
+		t.Error("boşluk/büyük harf kural adını bozdu")
+	}
+}
+
+// A list of only unknown names must not silently disable the WAF. Without
+// filtering, the family set is non-nil and matches nothing, so every request
+// passes — a typo in the rule list would turn the WAF off.
+func TestWAFUnknownRulesDoNotDisableEverything(t *testing.T) {
+	for _, saldiri := range []string{sqlSaldiri, xssSaldiri, yolSaldiri} {
+		if wafIstek(t, []string{"saçmalık"}, saldiri) {
+			t.Errorf("tanınmayan kural WAF'ı kapattı: %q geçti", saldiri)
+		}
+	}
+}
+
+// An unknown name mixed with a real one must be dropped, not widen the set.
+func TestWAFUnknownRuleDroppedFromMixedList(t *testing.T) {
+	rules := []string{WAFSQLInjection, "saçmalık"}
+
+	if wafIstek(t, rules, sqlSaldiri) {
+		t.Error("listelenen sql_injection uygulanmadı")
+	}
+	if !wafIstek(t, rules, xssSaldiri) {
+		t.Error("tanınmayan giriş listeyi genişletti — xss de uygulandı")
+	}
+}
+
+func TestKnownWAFRule(t *testing.T) {
+	for _, ok := range []string{"sql_injection", "XSS", " path_traversal ", "shell_injection", "php"} {
+		if !KnownWAFRule(ok) {
+			t.Errorf("%q tanınmadı", ok)
+		}
+	}
+	for _, kotu := range []string{"", "sqli", "saçmalık"} {
+		if KnownWAFRule(kotu) {
+			t.Errorf("%q tanındı", kotu)
+		}
+	}
+}
+
+// The body path must select families too.
+func TestWAFRulesApplyToBody(t *testing.T) {
+	guard := DomainWAFGuard(logger.New("error", "text"), nil, []string{WAFXSS}, nil)
+
+	govde := func(s string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/submit", strings.NewReader(s))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.RemoteAddr = "203.0.113.1:5000"
+		return r
+	}
+
+	if guard(httptest.NewRecorder(), govde("a=javascript:alert(1)")) {
+		t.Error("xss listelenmişken gövdedeki XSS geçti")
+	}
+	if !guard(httptest.NewRecorder(), govde("a=union+select+x+from+y")) {
+		t.Error("listelenmemiş sql_injection gövdede hâlâ uygulanıyor")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -598,7 +598,22 @@ func New(cfg *config.Config, log *logger.Logger) *Server {
 			})
 		}
 		if d.Security.WAF.Enabled {
-			s.wafGuards[d.Host] = middleware.DomainWAFGuard(log, d.Security.WAF.BypassPaths, s.securityStats)
+			// security.waf.rules was never read, so every WAF-enabled domain
+			// has been getting every family whatever it listed. Honouring the
+			// list now narrows coverage for anyone who set one — say which
+			// families are left rather than letting protection shrink
+			// silently on upgrade.
+			if len(d.Security.WAF.Rules) > 0 {
+				s.logger.Warn("security.waf.rules now selects which WAF families run; the others are no longer checked for this domain",
+					"domain", d.Host, "enabled", d.Security.WAF.Rules)
+				for _, r := range d.Security.WAF.Rules {
+					if !middleware.KnownWAFRule(r) {
+						s.logger.Warn("unknown security.waf.rules entry ignored",
+							"domain", d.Host, "rule", r, "known", middleware.WAFRuleNames())
+					}
+				}
+			}
+			s.wafGuards[d.Host] = middleware.DomainWAFGuard(log, d.Security.WAF.BypassPaths, d.Security.WAF.Rules, s.securityStats)
 		}
 	}
 

--- a/internal/server/server_reload.go
+++ b/internal/server/server_reload.go
@@ -95,7 +95,7 @@ func (s *Server) reload() error {
 			})
 		}
 		if d.Security.WAF.Enabled {
-			newWAFGuards[d.Host] = middleware.DomainWAFGuard(s.logger, d.Security.WAF.BypassPaths, s.securityStats)
+			newWAFGuards[d.Host] = middleware.DomainWAFGuard(s.logger, d.Security.WAF.BypassPaths, d.Security.WAF.Rules, s.securityStats)
 		}
 	}
 

--- a/test/integration/security_behavior_test.go
+++ b/test/integration/security_behavior_test.go
@@ -44,7 +44,7 @@ func newTestSecurityStats() *middleware.SecurityStats {
 // are blocked by the WAF guard.
 func TestWAF_BlocksSQLInjection(t *testing.T) {
 	stats := newTestSecurityStats()
-	guard := middleware.DomainWAFGuard(newTestLogger(), nil, stats)
+	guard := middleware.DomainWAFGuard(newTestLogger(), nil, nil, stats)
 
 	attackURLs := []string{
 		"/page?id=1%20UNION%20SELECT%20%2A%20FROM%20users",
@@ -68,7 +68,7 @@ func TestWAF_BlocksSQLInjection(t *testing.T) {
 // TestWAF_BlocksXSS verifies that XSS payloads in the URL are blocked.
 func TestWAF_BlocksXSS(t *testing.T) {
 	stats := newTestSecurityStats()
-	guard := middleware.DomainWAFGuard(newTestLogger(), nil, stats)
+	guard := middleware.DomainWAFGuard(newTestLogger(), nil, nil, stats)
 
 	attackURLs := []string{
 		"/search?q=%3Cscript%3Ealert%281%29%3C%2Fscript%3E",
@@ -89,7 +89,7 @@ func TestWAF_BlocksXSS(t *testing.T) {
 // TestWAF_BlocksPathTraversal verifies that ../ in the URL is blocked.
 func TestWAF_BlocksPathTraversal(t *testing.T) {
 	stats := newTestSecurityStats()
-	guard := middleware.DomainWAFGuard(newTestLogger(), nil, stats)
+	guard := middleware.DomainWAFGuard(newTestLogger(), nil, nil, stats)
 
 	attackURLs := []string{
 		"/../../../etc/passwd",
@@ -110,7 +110,7 @@ func TestWAF_BlocksPathTraversal(t *testing.T) {
 // TestWAF_BlocksShellInjection verifies that shell injection patterns are blocked.
 func TestWAF_BlocksShellInjection(t *testing.T) {
 	stats := newTestSecurityStats()
-	guard := middleware.DomainWAFGuard(newTestLogger(), nil, stats)
+	guard := middleware.DomainWAFGuard(newTestLogger(), nil, nil, stats)
 
 	attackURLs := []string{
 		"/cmd?exec=%3Bcat%20/etc/passwd",
@@ -132,7 +132,7 @@ func TestWAF_BlocksShellInjection(t *testing.T) {
 // /proc/self, etc. via URL are blocked.
 func TestWAF_BlocksSensitiveFiles(t *testing.T) {
 	stats := newTestSecurityStats()
-	guard := middleware.DomainWAFGuard(newTestLogger(), nil, stats)
+	guard := middleware.DomainWAFGuard(newTestLogger(), nil, nil, stats)
 
 	attackURLs := []string{
 		"/page?file=/etc/passwd",
@@ -153,7 +153,7 @@ func TestWAF_BlocksSensitiveFiles(t *testing.T) {
 // TestWAF_AllowsLegitimateRequests verifies that normal requests pass the WAF.
 func TestWAF_AllowsLegitimateRequests(t *testing.T) {
 	stats := newTestSecurityStats()
-	guard := middleware.DomainWAFGuard(newTestLogger(), nil, stats)
+	guard := middleware.DomainWAFGuard(newTestLogger(), nil, nil, stats)
 
 	legitURLs := []string{
 		"/",
@@ -178,7 +178,7 @@ func TestWAF_AllowsLegitimateRequests(t *testing.T) {
 func TestWAF_BypassPaths(t *testing.T) {
 	stats := newTestSecurityStats()
 	bypassPaths := []string{"/webhook/", "/api/callback"}
-	guard := middleware.DomainWAFGuard(newTestLogger(), bypassPaths, stats)
+	guard := middleware.DomainWAFGuard(newTestLogger(), bypassPaths, nil, stats)
 
 	// A URL that would normally be blocked by WAF, but is in a bypass path
 	req := httptest.NewRequest(http.MethodPost, "https://example.com/webhook/drop", strings.NewReader("x=<script>alert(1)</script>"))


### PR DESCRIPTION
`SPECIFICATION.md` bloğu şöyle belgeliyor:

```yaml
waf:
  enabled: true
  rules:
    - sql_injection
    - xss
    - path_traversal
```

`rules`'ı hiçbir yer okumuyordu. `DomainWAFGuard` yalnızca `bypassPaths` alıyor, dolayısıyla WAF açık her domain ne listelerse listelesin **bütün desenleri** koşuyordu.

Desenler zaten yorumlarda ailelere ayrılmıştı; artık etiketi taşıyorlar ve koruma domainin adlandırmadığı aileleri atlıyor. Boş ya da olmayan liste hâlâ "hepsi" demek — bugüne kadar olan da bu.

### Kaçınılması gereken iki tehlike

İkisini de **testleri önce yazarak** buldum.

**Tanınmayan bir ad**, hiçbir şeyle eşleşmeyen bir aile kümesi kurup her isteği geçirirdi — kural listesindeki bir yazım hatası **WAF'ı kapatırdı**. Tanınmayan adlar düşürülüyor; geriye kullanılabilir bir şey kalmazsa hiçbiri değil, **hepsi** uygulanıyor.

**Listeyi onurlandırmak kapsamı daraltıyor**, çünkü liste yazmış olanlar bugüne kadar her şeyi alıyordu. Sunucu açılışta kalan aileleri adlandırarak uyarıyor — koruma yükseltmede sessizce küçülmesin — ve tanınmayan her girdi için ayrıca uyarıyor.

### Keskinlik

Liste yok sayılınca:

```
--- FAIL: TestWAFRulesSelectFamilies
    yalnızca sql_injection listeliyken XSS de engellendi — rules seçim yapmıyor
--- FAIL: TestWAFRulesApplyToBody
    listelenmemiş sql_injection gövdede hâlâ uygulanıyor
```

### Bunu nasıl buldum

Ayrıca kaydetmeye değer: **dize eşleştiren tarayıcı bunu hiç bulamadı.** `.Rules` ağacın başka yerindeki önbellek kuralları ve rewrite kurallarıyla çakışıyor, dolayısıyla kullanılıyor gibi okunuyordu.

Ancak her seçim ifadesini gerçekten adlandırdığı alana çözen **tip-farkında** bir geçişten sonra ortaya çıktı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G
